### PR TITLE
Add pattern provider toolbar initialization event

### DIFF
--- a/src/main/java/ae2/api/client/PatternProviderGuiInitEvent.java
+++ b/src/main/java/ae2/api/client/PatternProviderGuiInitEvent.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2021, TeamAppliedEnergistics, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package ae2.api.client;
+
+import ae2.helpers.patternprovider.PatternProviderLogicHost;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Posted on the Forge event bus after a pattern provider GUI has added its built-in toolbar buttons.
+ * <p>
+ * Add-ons can use this event to append controls to the native pattern provider toolbar without depending on the
+ * GUI's internal widget implementation.
+ */
+@SideOnly(Side.CLIENT)
+public final class PatternProviderGuiInitEvent extends Event {
+
+    private final PatternProviderLogicHost host;
+    private final Consumer<GuiButton> leftToolbar;
+
+    public PatternProviderGuiInitEvent(PatternProviderLogicHost host, Consumer<GuiButton> leftToolbar) {
+        this.host = Objects.requireNonNull(host, "host");
+        this.leftToolbar = Objects.requireNonNull(leftToolbar, "leftToolbar");
+    }
+
+    /**
+     * @return the pattern provider host represented by the GUI
+     */
+    public PatternProviderLogicHost getHost() {
+        return this.host;
+    }
+
+    /**
+     * Appends a button to the native left toolbar.
+     *
+     * @return the supplied button, for convenient assignment
+     */
+    public <B extends GuiButton> B addToLeftToolbar(B button) {
+        this.leftToolbar.accept(Objects.requireNonNull(button, "button"));
+        return button;
+    }
+}

--- a/src/main/java/ae2/client/gui/implementations/GuiPatternProvider.java
+++ b/src/main/java/ae2/client/gui/implementations/GuiPatternProvider.java
@@ -1,5 +1,6 @@
 package ae2.client.gui.implementations;
 
+import ae2.api.client.PatternProviderGuiInitEvent;
 import ae2.api.config.BlockingMode;
 import ae2.api.config.LockCraftingMode;
 import ae2.api.config.PatternProviderBlockingType;
@@ -31,6 +32,7 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraftforge.common.MinecraftForge;
 
 import java.util.List;
 
@@ -88,6 +90,8 @@ public class GuiPatternProvider extends AEBaseGui<ContainerPatternProvider> {
         this.patternModifierPanel = new PatternModifierPanelWidget(this, new PatternProviderPanelHost());
         this.patternModifierPanel.addButtons();
         addToLeftToolbar(this.patternModifierPanel.getToolbarButton());
+        MinecraftForge.EVENT_BUS.post(
+            new PatternProviderGuiInitEvent(container.getHost(), this::addToLeftToolbar));
     }
 
     @Override

--- a/src/main/java/ae2/container/implementations/ContainerPatternProvider.java
+++ b/src/main/java/ae2/container/implementations/ContainerPatternProvider.java
@@ -42,6 +42,7 @@ public class ContainerPatternProvider extends AEBaseContainer
     public static final String ACTION_SET_PAGE = "setPage";
     @GuiSync(12)
     public final boolean remote;
+    private final PatternProviderLogicHost host;
     private final PatternProviderLogic logic;
     private final List<AppEngSlot> patternSlots = new ObjectArrayList<>();
     private final PatternModifierPanel patternModifierPanel;
@@ -73,6 +74,7 @@ public class ContainerPatternProvider extends AEBaseContainer
 
     public ContainerPatternProvider(InventoryPlayer playerInventory, PatternProviderLogicHost host) {
         super(playerInventory, host);
+        this.host = host;
         this.logic = host.getLogic();
         this.remote = playerInventory.player.openContainer instanceof ContainerPatternAccessTerm;
         this.registerClientAction(ACTION_SET_PAGE, Integer.class, this::setPage);
@@ -155,6 +157,10 @@ public class ContainerPatternProvider extends AEBaseContainer
 
     public PatternProviderLogic getLogic() {
         return this.logic;
+    }
+
+    public PatternProviderLogicHost getHost() {
+        return this.host;
     }
 
     public BlockingMode getBlockingMode() {


### PR DESCRIPTION
## Summary
- add a client-side `PatternProviderGuiInitEvent`
- expose the active `PatternProviderLogicHost` through `ContainerPatternProvider`
- allow addons to append buttons through the native left toolbar without accessing `VerticalButtonBar`

## Motivation
Addons that provide their own `PatternProviderLogicHost` currently need a GUI mixin or accessor solely to append a control to the native pattern provider toolbar. The event is posted after all built-in toolbar buttons have been added and exposes only the stable host plus an `addToLeftToolbar` callback.

The event does not expose `GuiPatternProvider` or the internal toolbar implementation, and addon-specific networking/state remains outside AE2S.

## Example
```java
@SubscribeEvent
public static void initializePatternProviderGui(PatternProviderGuiInitEvent event) {
    if (event.getHost() instanceof MyPatternProviderHost) {
        event.addToLeftToolbar(new MyAddonButton());
    }
}
```

## Verification
- fork GitHub Actions build started for this branch