### PR TITLE
New api for Applied-Flux

### DIFF
--- a/API.md
+++ b/API.md
@@ -29,6 +29,7 @@ relevant during normal Forge mod initialization:
 | `ae2.api.client.StorageCellModels`          | For customizing the models of storage cells when they are inserted into drives or ME chests.        |
 | `ae2.api.upgrades.Upgrades`                 | For managing upgrade cards and associating them with upgradable items, parts, or blocks.            |
 | `ae2.api.upgrades.UpgradeInventories`       | For creating upgrade inventories for upgradable machines and item-backed hosts.                     |
+| `ae2.api.networking.extensions.GridLogicExtensions` | Adds runtime behavior to supported AE2 grid logic instances without mixins.                  |
 | `ae2.api.behaviors.GenericInternalInventoryAdapters` | Allows addons to expose AE2 generic inventories through Forge capabilities.                         |
 
 In general, these registries are synchronized and may be used during mod loading. Finish registration before gameplay
@@ -53,6 +54,12 @@ or filtering.
 Each type of key is represented by an instance of `AEKeyType`, accessible via `AEKey.getType()`. It stores properties
 common to all keys of a type, such as amount formatting, bytes per amount, operation amount, the packet reader, and
 the NBT reader. New key families are registered through `AEKeyTypes.register`.
+
+Key types that cannot be delivered as crafting CPU output should override
+`AEKeyType.isCraftingCpuInsertable()` to return `false`. AE2 will then neither prefer the crafting CPU storage mount
+for the type nor forward inserts to crafting CPUs. This is appropriate for resource families such as externally
+produced energy that may be stored in a network but are not valid crafting results. It does not disable pattern
+registration or crafting-plan calculation for the key type.
 
 Keys can be saved to NBT using `toTagGeneric`, which also stores a reference to their type so that
 `AEKey.fromTagGeneric` can restore the key without the caller knowing the exact key class. The same mechanism can be
@@ -421,6 +428,31 @@ through `Upgrades.add(upgradeCard, upgradableObject, maxSupported, tooltipGroup)
 upgrade card, all supported machines with the same `tooltipGroup` are merged into a single translated line. AE2 uses
 this for related block/part forms and related item/fluid variants.
 
+### Physical Upgrade Slots
+
+The maximum number of copies of a card accepted by `Upgrades.add(...)` is independent from the number of physical
+slots on a machine. A machine may deliberately expose fewer slots than the sum of all supported card maxima, requiring
+the player to choose between compatible upgrades.
+
+Addons can contribute physical slots to an existing machine with `Upgrades.addUpgradeSlots(...)`:
+
+```java
+ResourceLocation id = new ResourceLocation("examplemod", "high_voltage_slot");
+
+Upgrades.add(HIGH_VOLTAGE_CARD, MY_MACHINE_ITEM, 1);
+Upgrades.addUpgradeSlots(MY_MACHINE_ITEM, id, 1);
+```
+
+The contribution id is unique per machine item. Reusing an id, supplying a non-positive slot count, or registering
+after the machine's upgrade-slot count has first been resolved throws an exception. Distinct addon ids are additive.
+This makes a feature that adds a card and a slot explicit while retaining the machine author's base capacity and
+upgrade trade-offs.
+
+`UpgradeInventories.forMachine(machine, baseSlots, callback)` automatically includes registered contributions.
+Custom machine inventories should call `UpgradeInventories.getMachineUpgradeSlots(machine, baseSlots)` exactly once
+when constructing their inventory. Both methods freeze further slot contributions for that machine, so register them
+during mod initialization before any instance of the machine can be created.
+
 ### Making Custom Machines or Items Upgradable
 
 Use `UpgradeInventories` to create inventories for storing upgrade cards. These inventories use the provided machine
@@ -432,6 +464,61 @@ many upgrades of a type are installed, and iterate over installed cards.
 For the machine version created by `UpgradeInventories.forMachine`, save the inventory from the change callback. For
 the item version created by `UpgradeInventories.forItem`, the upgrade inventory writes changes directly into the
 provided `ItemStack` NBT. The item variant also accepts an optional change callback.
+
+## Extending Built-In Grid Logic
+
+`GridLogicExtensions` lets addons attach independent runtime behavior to supported AE2 grid logic without mixins,
+access transformers, or references to private fields. The current built-in integration points are ME interfaces and
+pattern providers, for both their block and part forms.
+
+Register a factory for each machine item during mod initialization:
+
+```java
+ResourceLocation id = new ResourceLocation("examplemod", "network_monitor");
+GridLogicExtensions.register(MY_MACHINE_ITEM, id, MyLogicExtension::new);
+```
+
+Registration ids are unique per machine item. Registrations for a machine are frozen when its first logic instance is
+created; duplicate or late registrations throw an exception so a world cannot contain machines with different
+extension sets.
+
+The factory receives a `GridLogicContext`, which exposes the machine item, owning block entity or part, host tile,
+managed grid node, action source, upgrade inventory, and a current snapshot of target sides. The host tile is the
+containing `TileEntity`; for a part, the owner returned by `getOwner()` is the part while the host tile is normally the
+cable bus tile.
+
+Implement `GridLogicExtension` for lifecycle callbacks:
+
+```java
+final class MyLogicExtension implements GridLogicExtension {
+    private final GridLogicContext context;
+
+    MyLogicExtension(GridLogicContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public void initialize(GridLogicContext context) {
+        context.getManagedNode().addService(IMyNodeService.class, new MyNodeService(context));
+    }
+
+    @Override
+    public void onUpgradesChanged() {
+        // Reconfigure behavior after AE2 has processed the upgrade change.
+    }
+
+    @Override
+    public void onNeighborChanged(EnumFacing side) {
+        // Invalidate state associated with this adjacent side.
+    }
+}
+```
+
+Factories create all extensions first. AE2 then calls `initialize(...)` after the complete extension list is attached
+to the owning logic, so initialization can safely cause follow-up logic activity. `onUpgradesChanged()` is dispatched
+after AE2's native upgrade handling. Neighbor callbacks are dispatched server-side for immediately adjacent block
+changes; an extension should use `context.getTargetSides()` when it only handles current output sides, because a
+pattern provider's selected side can change at runtime.
 
 ## Wireless Terminals
 

--- a/src/main/java/ae2/api/networking/extensions/GridLogicContext.java
+++ b/src/main/java/ae2/api/networking/extensions/GridLogicContext.java
@@ -1,0 +1,77 @@
+package ae2.api.networking.extensions;
+
+import ae2.api.networking.IManagedGridNode;
+import ae2.api.networking.security.IActionSource;
+import ae2.api.upgrades.IUpgradeInventory;
+import net.minecraft.item.Item;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * Stable access to the state shared by AE2 grid logic implementations.
+ */
+public final class GridLogicContext {
+    private final Item machineType;
+    private final Object owner;
+    private final IManagedGridNode managedNode;
+    private final IActionSource actionSource;
+    private final IUpgradeInventory upgrades;
+    private final TileEntity host;
+    private final Supplier<? extends Set<EnumFacing>> targetSides;
+
+    public GridLogicContext(Item machineType, Object owner, IManagedGridNode managedNode, IActionSource actionSource,
+                            IUpgradeInventory upgrades, TileEntity host,
+                            Supplier<? extends Set<EnumFacing>> targetSides) {
+        this.machineType = Objects.requireNonNull(machineType, "machineType");
+        this.owner = Objects.requireNonNull(owner, "owner");
+        this.managedNode = Objects.requireNonNull(managedNode, "managedNode");
+        this.actionSource = Objects.requireNonNull(actionSource, "actionSource");
+        this.upgrades = Objects.requireNonNull(upgrades, "upgrades");
+        this.host = Objects.requireNonNull(host, "host");
+        this.targetSides = Objects.requireNonNull(targetSides, "targetSides");
+    }
+
+    public Item getMachineType() {
+        return machineType;
+    }
+
+    /**
+     * Returns the logic owner, usually the owning block entity or part.
+     */
+    public Object getOwner() {
+        return owner;
+    }
+
+    public IManagedGridNode getManagedNode() {
+        return managedNode;
+    }
+
+    public IActionSource getActionSource() {
+        return actionSource;
+    }
+
+    public IUpgradeInventory getUpgrades() {
+        return upgrades;
+    }
+
+    public TileEntity getHostTile() {
+        return host;
+    }
+
+    /**
+     * Returns a snapshot of the sides this machine currently targets.
+     */
+    public Set<EnumFacing> getTargetSides() {
+        var sides = Objects.requireNonNull(targetSides.get(), "targetSides returned null");
+        if (sides.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return Collections.unmodifiableSet(EnumSet.copyOf(sides));
+    }
+}

--- a/src/main/java/ae2/api/networking/extensions/GridLogicExtension.java
+++ b/src/main/java/ae2/api/networking/extensions/GridLogicExtension.java
@@ -1,0 +1,27 @@
+package ae2.api.networking.extensions;
+
+import net.minecraft.util.EnumFacing;
+
+/**
+ * Adds behavior to an AE2-owned grid logic instance without replacing its implementation.
+ */
+public interface GridLogicExtension {
+
+    /**
+     * Called after every extension for the logic instance has been constructed and attached to the logic.
+     */
+    default void initialize(GridLogicContext context) {
+    }
+
+    /**
+     * Called after the machine's upgrade inventory changes.
+     */
+    default void onUpgradesChanged() {
+    }
+
+    /**
+     * Called when an adjacent block relevant to the machine changes.
+     */
+    default void onNeighborChanged(EnumFacing side) {
+    }
+}

--- a/src/main/java/ae2/api/networking/extensions/GridLogicExtensionFactory.java
+++ b/src/main/java/ae2/api/networking/extensions/GridLogicExtensionFactory.java
@@ -1,0 +1,7 @@
+package ae2.api.networking.extensions;
+
+@FunctionalInterface
+public interface GridLogicExtensionFactory {
+
+    GridLogicExtension create(GridLogicContext context);
+}

--- a/src/main/java/ae2/api/networking/extensions/GridLogicExtensions.java
+++ b/src/main/java/ae2/api/networking/extensions/GridLogicExtensions.java
@@ -1,0 +1,96 @@
+package ae2.api.networking.extensions;
+
+import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import net.minecraft.item.Item;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Registry for attaching independent behavior to AE2 grid logic instances.
+ */
+public final class GridLogicExtensions {
+    private static final Reference2ObjectMap<Item, Map<ResourceLocation, GridLogicExtensionFactory>> FACTORIES =
+        new Reference2ObjectOpenHashMap<>();
+    private static final Set<Item> FROZEN_REGISTRATIONS = java.util.Collections.newSetFromMap(
+        new java.util.IdentityHashMap<>());
+
+    private GridLogicExtensions() {
+    }
+
+    /**
+     * Registers an extension factory for a machine item. Registration must happen before instances of that machine are
+     * created. The id must be unique for the given machine.
+     */
+    public static synchronized void register(Item machineType, ResourceLocation registrationId,
+                                             GridLogicExtensionFactory factory) {
+        Objects.requireNonNull(machineType, "machineType");
+        Objects.requireNonNull(registrationId, "registrationId");
+        Objects.requireNonNull(factory, "factory");
+        if (FROZEN_REGISTRATIONS.contains(machineType)) {
+            throw new IllegalStateException("Grid logic extension registrations are already frozen for " + machineType);
+        }
+
+        var registrations = FACTORIES.computeIfAbsent(machineType, ignored -> new LinkedHashMap<>());
+        var previous = registrations.putIfAbsent(registrationId, factory);
+        if (previous != null) {
+            throw new IllegalStateException("Grid logic extension " + registrationId
+                + " is already registered for " + machineType);
+        }
+    }
+
+    /**
+     * Creates the extensions registered for a logic context. Custom grid logic implementations can call this to opt in
+     * to the same extension mechanism.
+     */
+    public static List<GridLogicExtension> create(GridLogicContext context) {
+        Objects.requireNonNull(context, "context");
+        List<GridLogicExtensionFactory> factories;
+        synchronized (GridLogicExtensions.class) {
+            FROZEN_REGISTRATIONS.add(context.getMachineType());
+            var registrations = FACTORIES.get(context.getMachineType());
+            factories = registrations == null ? List.of() : List.copyOf(registrations.values());
+        }
+
+        var extensions = new ArrayList<GridLogicExtension>(factories.size());
+        for (var factory : factories) {
+            extensions.add(Objects.requireNonNull(factory.create(context), "extension factory returned null"));
+        }
+        return List.copyOf(extensions);
+    }
+
+    /**
+     * Initializes a complete extension set after the owning logic has stored it.
+     */
+    public static void initialize(List<GridLogicExtension> extensions, GridLogicContext context) {
+        Objects.requireNonNull(extensions, "extensions");
+        Objects.requireNonNull(context, "context");
+        for (var extension : extensions) {
+            extension.initialize(context);
+        }
+    }
+
+    /**
+     * Returns the side of an immediately adjacent position, or {@code null} if the positions are not adjacent.
+     */
+    @Nullable
+    public static EnumFacing getNeighborSide(BlockPos origin, BlockPos neighbor) {
+        Objects.requireNonNull(origin, "origin");
+        Objects.requireNonNull(neighbor, "neighbor");
+        for (var side : EnumFacing.VALUES) {
+            if (origin.offset(side).equals(neighbor)) {
+                return side;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/ae2/api/stacks/AEKeyType.java
+++ b/src/main/java/ae2/api/stacks/AEKeyType.java
@@ -109,6 +109,13 @@ public abstract class AEKeyType {
         return false;
     }
 
+    /**
+     * Returns whether crafting CPUs may intercept inserted keys of this type as crafting output.
+     */
+    public boolean isCraftingCpuInsertable() {
+        return true;
+    }
+
     public final AEKeyFilter filter() {
         return filter;
     }

--- a/src/main/java/ae2/api/upgrades/UpgradeInventories.java
+++ b/src/main/java/ae2/api/upgrades/UpgradeInventories.java
@@ -24,7 +24,19 @@ public final class UpgradeInventories {
      */
     public static IUpgradeInventory forMachine(Item machineType, int maxUpgrades,
                                                MachineUpgradesChanged changeCallback) {
-        return new MachineUpgradeInventory(machineType, maxUpgrades, changeCallback);
+        return new MachineUpgradeInventory(machineType, getMachineUpgradeSlots(machineType, maxUpgrades),
+            changeCallback);
+    }
+
+    /**
+     * Resolves a machine's physical upgrade inventory size from its base slots and registered slot contributions.
+     * Calling this freezes further slot registrations for the machine.
+     */
+    public static int getMachineUpgradeSlots(Item machineType, int baseSlots) {
+        if (baseSlots < 0) {
+            throw new IllegalArgumentException("baseSlots must not be negative");
+        }
+        return Math.addExact(baseSlots, Upgrades.getAdditionalUpgradeSlots(machineType));
     }
 
     /**

--- a/src/main/java/ae2/api/upgrades/Upgrades.java
+++ b/src/main/java/ae2/api/upgrades/Upgrades.java
@@ -7,10 +7,12 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectList;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextComponentTranslation;
@@ -18,14 +20,19 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public final class Upgrades {
     private static final Reference2ObjectMap<Item, List<Association>> ASSOCIATIONS = new Reference2ObjectOpenHashMap<>();
     private static final Reference2ObjectMap<IUpgradeableItem, Set<Item>> SUPPORTED_ITEM_UPGRADES = new Reference2ObjectOpenHashMap<>();
     private static final Reference2ObjectMap<Item, List<ITextComponent>> UPGRADE_CARD_TOOLTIP_LINES = new Reference2ObjectOpenHashMap<>();
+    private static final Reference2ObjectMap<Item, Map<ResourceLocation, Integer>> ADDITIONAL_SLOTS =
+        new Reference2ObjectOpenHashMap<>();
+    private static final Set<Item> FROZEN_SLOT_REGISTRATIONS = new ReferenceOpenHashSet<>();
 
     private Upgrades() {
     }
@@ -65,6 +72,51 @@ public final class Upgrades {
         }
 
         return 0;
+    }
+
+    /**
+     * Adds physical upgrade slots to a machine independently of which upgrade cards it supports.
+     * <p>
+     * The registration id must be unique for the given machine. This makes registrations additive across mods while
+     * preventing the same contribution from being applied twice.
+     *
+     * @param upgradableItem machine receiving the additional slots
+     * @param registrationId unique id for this slot contribution
+     * @param slots number of slots to add, must be positive
+     */
+    public static synchronized void addUpgradeSlots(Item upgradableItem, ResourceLocation registrationId, int slots) {
+        Objects.requireNonNull(upgradableItem, "upgradableItem");
+        Objects.requireNonNull(registrationId, "registrationId");
+        if (slots <= 0) {
+            throw new IllegalArgumentException("slots must be positive");
+        }
+        if (FROZEN_SLOT_REGISTRATIONS.contains(upgradableItem)) {
+            throw new IllegalStateException("Upgrade slot registrations are already frozen for " + upgradableItem);
+        }
+
+        var registrations = ADDITIONAL_SLOTS.computeIfAbsent(upgradableItem, ignored -> new LinkedHashMap<>());
+        var previous = registrations.putIfAbsent(registrationId, slots);
+        if (previous != null) {
+            throw new IllegalStateException("Upgrade slot contribution " + registrationId
+                + " is already registered for " + upgradableItem);
+        }
+    }
+
+    /**
+     * Returns the sum of all registered physical upgrade slot contributions for a machine.
+     */
+    public static synchronized int getAdditionalUpgradeSlots(Item upgradableItem) {
+        FROZEN_SLOT_REGISTRATIONS.add(upgradableItem);
+        var registrations = ADDITIONAL_SLOTS.get(upgradableItem);
+        if (registrations == null) {
+            return 0;
+        }
+
+        int result = 0;
+        for (var slots : registrations.values()) {
+            result = Math.addExact(result, slots);
+        }
+        return result;
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/ae2/block/crafting/PatternProviderBlock.java
+++ b/src/main/java/ae2/block/crafting/PatternProviderBlock.java
@@ -17,6 +17,7 @@
  */
 package ae2.block.crafting;
 
+import ae2.api.networking.extensions.GridLogicExtensions;
 import ae2.block.AEBaseTileBlock;
 import ae2.core.gui.locator.GuiHostLocators;
 import ae2.tile.crafting.TilePatternProvider;
@@ -72,6 +73,10 @@ public class PatternProviderBlock extends AEBaseTileBlock<TilePatternProvider> {
         if (tile != null) {
             tile.getLogic().invalidateTargetCaches();
             tile.getLogic().updateRedstoneState();
+            var side = GridLogicExtensions.getNeighborSide(pos, fromPos);
+            if (side != null && !world.isRemote) {
+                tile.getLogic().onNeighborChanged(side);
+            }
         }
     }
 

--- a/src/main/java/ae2/block/misc/InterfaceBlock.java
+++ b/src/main/java/ae2/block/misc/InterfaceBlock.java
@@ -17,10 +17,12 @@
  */
 package ae2.block.misc;
 
+import ae2.api.networking.extensions.GridLogicExtensions;
 import ae2.block.AEBaseTileBlock;
 import ae2.core.gui.locator.GuiHostLocators;
 import ae2.tile.misc.TileInterface;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumFacing;
@@ -52,6 +54,20 @@ public class InterfaceBlock extends AEBaseTileBlock<TileInterface> {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public void neighborChanged(IBlockState state, World world, BlockPos pos, Block blockIn, BlockPos fromPos) {
+        super.neighborChanged(state, world, pos, blockIn, fromPos);
+        if (world.isRemote) {
+            return;
+        }
+
+        var side = GridLogicExtensions.getNeighborSide(pos, fromPos);
+        var tile = this.getTileEntity(world, pos);
+        if (side != null && tile != null) {
+            tile.getInterfaceLogic().onNeighborChanged(side);
+        }
     }
 }
 

--- a/src/main/java/ae2/helpers/InterfaceLogic.java
+++ b/src/main/java/ae2/helpers/InterfaceLogic.java
@@ -12,6 +12,9 @@ import ae2.api.networking.crafting.ICraftingLink;
 import ae2.api.networking.crafting.ICraftingPlan;
 import ae2.api.networking.crafting.ICraftingRequester;
 import ae2.api.networking.energy.IEnergySource;
+import ae2.api.networking.extensions.GridLogicContext;
+import ae2.api.networking.extensions.GridLogicExtension;
+import ae2.api.networking.extensions.GridLogicExtensions;
 import ae2.api.networking.security.IActionHost;
 import ae2.api.networking.security.IActionSource;
 import ae2.api.networking.ticking.IGridTickable;
@@ -61,6 +64,7 @@ public class InterfaceLogic implements ICraftingForceStartRequester, IUpgradeabl
     protected final IActionSource interfaceRequestSource;
     private final MultiCraftingTracker craftingTracker;
     private final IUpgradeInventory upgrades;
+    private final List<GridLogicExtension> extensions;
     private final IConfigManager cm;
     private final GenericStack[] plannedWork;
     private final ConfigInventory config;
@@ -97,6 +101,10 @@ public class InterfaceLogic implements ICraftingForceStartRequester, IUpgradeabl
 
         this.getConfig().useRegisteredCapacities();
         this.getStorage().useRegisteredCapacities();
+        var extensionContext = new GridLogicContext(machineType, host, this.mainNode, this.actionSource,
+            this.upgrades, host.getTileEntity(), host::getTargets);
+        this.extensions = GridLogicExtensions.create(extensionContext);
+        GridLogicExtensions.initialize(this.extensions, extensionContext);
     }
 
     public static boolean isForceStartCraftingEnabled(Iterable<ItemStack> upgrades) {
@@ -418,6 +426,15 @@ public class InterfaceLogic implements ICraftingForceStartRequester, IUpgradeabl
         }
 
         this.updatePlan();
+        for (var extension : this.extensions) {
+            extension.onUpgradesChanged();
+        }
+    }
+
+    public void onNeighborChanged(EnumFacing side) {
+        for (var extension : this.extensions) {
+            extension.onNeighborChanged(side);
+        }
     }
 
     private void onConfigRowChanged() {

--- a/src/main/java/ae2/helpers/InterfaceLogicHost.java
+++ b/src/main/java/ae2/helpers/InterfaceLogicHost.java
@@ -12,10 +12,18 @@ import ae2.helpers.externalstorage.GenericStackInv;
 import ae2.parts.AEBasePart;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.EnumSet;
+import java.util.Set;
 
 public interface InterfaceLogicHost extends IConfigurableObject, IUpgradeableObject, IPriorityHost, IConfigInvHost {
     TileEntity getTileEntity();
+
+    default Set<EnumFacing> getTargets() {
+        return EnumSet.allOf(EnumFacing.class);
+    }
 
     void saveChanges();
 

--- a/src/main/java/ae2/helpers/patternprovider/PatternProviderLogic.java
+++ b/src/main/java/ae2/helpers/patternprovider/PatternProviderLogic.java
@@ -43,6 +43,9 @@ import ae2.api.networking.IGridConnection;
 import ae2.api.networking.IGridNode;
 import ae2.api.networking.IManagedGridNode;
 import ae2.api.networking.crafting.ICraftingProvider;
+import ae2.api.networking.extensions.GridLogicContext;
+import ae2.api.networking.extensions.GridLogicExtension;
+import ae2.api.networking.extensions.GridLogicExtensions;
 import ae2.api.networking.security.IActionHost;
 import ae2.api.networking.security.IActionSource;
 import ae2.api.networking.ticking.IGridTickable;
@@ -56,6 +59,7 @@ import ae2.api.stacks.AEKeyType;
 import ae2.api.stacks.GenericStack;
 import ae2.api.stacks.KeyCounter;
 import ae2.api.upgrades.IUpgradeInventory;
+import ae2.api.upgrades.UpgradeInventories;
 import ae2.api.upgrades.Upgrades;
 import ae2.api.util.IConfigManager;
 import ae2.core.AEConfig;
@@ -137,6 +141,7 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
     private final AppEngInternalInventory patternInventory;
     private final InternalInventory terminalPatternInventory = new ActivePatternInventory();
     private final IUpgradeInventory upgrades;
+    private final List<GridLogicExtension> extensions;
     private final ObjectList<IPatternDetails> patterns = new ObjectArrayList<>();
     private final ObjectSet<AEItemKey> patternKeys = new ObjectOpenHashSet<>();
     private final ObjectSet<AEKey> patternInputs = new ObjectOpenHashSet<>();
@@ -187,11 +192,16 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
                                            .build();
         this.patternInventory = new AppEngInternalInventory(this, patternInventorySize, 1, new PatternInventoryFilter());
         this.upgrades = new PatternProviderUpgradeInventory(machineType,
-            1 + AEConfig.instance().getPatternProviderExpansionCardLimit());
+            UpgradeInventories.getMachineUpgradeSlots(machineType,
+                1 + AEConfig.instance().getPatternProviderExpansionCardLimit()));
         this.returnInv = new PatternProviderReturnInventory(() -> {
             this.mainNode.ifPresent((grid, node) -> grid.getTickManager().alertDevice(node));
             this.host.saveChanges();
         });
+        var extensionContext = new GridLogicContext(machineType, host, this.mainNode, this.actionSource,
+            this.upgrades, hostTile, host::getTargets);
+        this.extensions = GridLogicExtensions.create(extensionContext);
+        GridLogicExtensions.initialize(this.extensions, extensionContext);
     }
 
     private static int countItem(InventoryPlayer inventory, ItemStack needle) {
@@ -238,6 +248,15 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
         this.host.saveChanges();
         this.updatePatterns();
         ICraftingProvider.requestUpdate(this.mainNode);
+        for (var extension : this.extensions) {
+            extension.onUpgradesChanged();
+        }
+    }
+
+    public void onNeighborChanged(EnumFacing side) {
+        for (var extension : this.extensions) {
+            extension.onNeighborChanged(side);
+        }
     }
 
     private boolean isPatternSlotOccupied(int slot) {

--- a/src/main/java/ae2/me/service/helpers/CraftingServiceStorage.java
+++ b/src/main/java/ae2/me/service/helpers/CraftingServiceStorage.java
@@ -40,11 +40,14 @@ public class CraftingServiceStorage implements IStorageProvider {
     private final MEStorage inventory = new MEStorage() {
         @Override
         public boolean isPreferredStorageFor(AEKey key, IActionSource source) {
-            return true;
+            return key.getType().isCraftingCpuInsertable();
         }
 
         @Override
         public long insert(AEKey what, long amount, Actionable mode, IActionSource source) {
+            if (!what.getType().isCraftingCpuInsertable()) {
+                return 0;
+            }
             // Item interception logic
             return craftingService.insertIntoCpus(what, amount, mode);
         }

--- a/src/main/java/ae2/parts/crafting/PatternProviderPart.java
+++ b/src/main/java/ae2/parts/crafting/PatternProviderPart.java
@@ -19,6 +19,7 @@
 package ae2.parts.crafting;
 
 import ae2.api.networking.IGridNodeListener;
+import ae2.api.networking.extensions.GridLogicExtensions;
 import ae2.api.parts.IPartCollisionHelper;
 import ae2.api.parts.IPartItem;
 import ae2.api.parts.IPartModel;
@@ -155,6 +156,10 @@ public class PatternProviderPart extends AEBasePart implements PatternProviderLo
     public void onNeighborChanged(IBlockAccess level, BlockPos pos, BlockPos neighbor) {
         this.logic.invalidateTargetCaches();
         this.logic.updateRedstoneState();
+        var side = GridLogicExtensions.getNeighborSide(pos, neighbor);
+        if (side != null && side == getSide() && !isClientSide()) {
+            this.logic.onNeighborChanged(side);
+        }
     }
 
     @Override

--- a/src/main/java/ae2/parts/misc/InterfacePart.java
+++ b/src/main/java/ae2/parts/misc/InterfacePart.java
@@ -5,6 +5,7 @@ import ae2.api.networking.GridHelper;
 import ae2.api.networking.IGridNode;
 import ae2.api.networking.IGridNodeListener;
 import ae2.api.networking.IManagedGridNode;
+import ae2.api.networking.extensions.GridLogicExtensions;
 import ae2.api.parts.IPartCollisionHelper;
 import ae2.api.parts.IPartItem;
 import ae2.api.parts.IPartModel;
@@ -21,11 +22,15 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.Constants;
 
 import org.jetbrains.annotations.Nullable;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 public class InterfacePart extends AEBasePart implements InterfaceLogicHost {
     private static final String CELL_TERMINAL_SUBNET_ID_TAG = "cellTerminalSubnetId";
@@ -135,6 +140,19 @@ public class InterfacePart extends AEBasePart implements InterfaceLogicHost {
     @Override
     public InterfaceLogic getInterfaceLogic() {
         return this.logic;
+    }
+
+    @Override
+    public Set<net.minecraft.util.EnumFacing> getTargets() {
+        return EnumSet.of(getSide());
+    }
+
+    @Override
+    public void onNeighborChanged(IBlockAccess level, BlockPos pos, BlockPos neighbor) {
+        var side = GridLogicExtensions.getNeighborSide(pos, neighbor);
+        if (side != null && side == getSide() && !isClientSide()) {
+            this.logic.onNeighborChanged(side);
+        }
     }
 
     @Override


### PR DESCRIPTION
包含：
- 	AEKeyType.isCraftingCpuInsertable()
- 	Upgrades.addUpgradeSlots(...) 与 UpgradeInventories.getMachineUpgradeSlots(...)
- 	GridLogicExtensions、GridLogicContext 和生命周期回调

用法见 API.md
