### PR TITLE
# EnergyService Refactor

### DIFF
--- a/src/main/java/ae2/api/networking/energy/IAEPowerStorage.java
+++ b/src/main/java/ae2/api/networking/energy/IAEPowerStorage.java
@@ -23,10 +23,13 @@
 
 package ae2.api.networking.energy;
 
+import java.util.Objects;
+
 import ae2.api.config.AccessRestriction;
 import ae2.api.config.Actionable;
 import ae2.api.networking.IGrid;
 import ae2.api.networking.IGridNodeService;
+import ae2.api.networking.events.GridPowerStorageChanged;
 
 /**
  * Used to access information about AE's various power accepting blocks for monitoring purposes.
@@ -43,18 +46,56 @@ public interface IAEPowerStorage extends IEnergySource, IGridNodeService {
     double injectAEPower(double amt, Actionable mode);
 
     /**
-     * @return the current maximum power ( this can change :P )
+     * If this value changes while the storage is registered, post a
+     * {@link GridPowerStorageChanged.ChangeType#ROUTING_CHANGED} event because maximum capacity controls service
+     * grouping.
+     *
+     * @return the current maximum power
      */
     double getAEMaxPower();
 
     /**
+     * Changes to current, extractable or receivable power must post a
+     * {@link GridPowerStorageChanged.ChangeType#VALUES_CHANGED} event unless they were caused by an operation invoked
+     * through the energy service, which performs an immediate absolute snapshot correction.
+     *
      * @return the current AE Power Level, this may exceed getMEMaxPower()
      */
     double getAECurrentPower();
 
     /**
+     * Writes a complete snapshot used by the overlay energy cache into the supplied reusable builder.
+     * <p>
+     * This method must be side-effect free, must call
+     * {@link PowerStorageSnapshotBuilder#setValues(double, double, double, double, AccessRestriction, int, boolean)}
+     * exactly once and must not retain the builder. Implementations with transfer limits or other dynamic availability
+     * rules should override this method so extractable and receivable power describe what one operation can perform at
+     * the time of the call.
+     * <p>
+     * The default implementation derives the complete snapshot from {@link #getAECurrentPower()},
+     * {@link #getAEMaxPower()}, {@link #getPowerFlow()}, {@link #getPriority()} and
+     * {@link #isAEPublicPowerStorage()}.
+     *
+     * @param builder reusable destination owned by the energy service
+     */
+    default void getPowerSnapshot(PowerStorageSnapshotBuilder builder) {
+        Objects.requireNonNull(builder, "builder");
+
+        double currentPower = getAECurrentPower();
+        double maximumPower = getAEMaxPower();
+        double receivablePower = Math.max(0, maximumPower - currentPower);
+        AccessRestriction powerFlow = getPowerFlow();
+        int priority = getPriority();
+        boolean publicStorage = isAEPublicPowerStorage();
+        builder.setValues(currentPower, maximumPower, currentPower, receivablePower, powerFlow, priority,
+            publicStorage);
+    }
+
+    /**
      * Checked on network reset to see if your block can be used as a public power storage ( use getPowerFlow to control
      * the behavior )
+     * <p>
+     * If this value changes while registered, post a {@link GridPowerStorageChanged.ChangeType#ROUTING_CHANGED} event.
      *
      * @return true if it can be used as a public power storage
      */
@@ -62,6 +103,8 @@ public interface IAEPowerStorage extends IEnergySource, IGridNodeService {
 
     /**
      * Control the power flow by telling what the network can do, either add? or subtract? or both!
+     * <p>
+     * If this value changes while registered, post a {@link GridPowerStorageChanged.ChangeType#ROUTING_CHANGED} event.
      *
      * @return access restriction what the network can do
      */
@@ -71,8 +114,8 @@ public interface IAEPowerStorage extends IEnergySource, IGridNodeService {
     /**
      * The priority to use this energy storage.
      * A higher Value means it is more likely to be extracted from first, and less likely to be inserted into first.
-     * The Value needs to be constant once added to a {@link IGrid}. Should it ever need to be changed, it has to be
-     * removed from the grid, then update the Value, and finally added back to the grid.
+     * If the value changes after the storage is added to an {@link IGrid}, post a
+     * {@link GridPowerStorageChanged.ChangeType#ROUTING_CHANGED} event so the service-local order is rebuilt lazily.
      * This should never use {@link Integer#MIN_VALUE} or {@link Integer#MAX_VALUE}.
      *
      * @return the priority for this storage

--- a/src/main/java/ae2/api/networking/energy/IEnergyService.java
+++ b/src/main/java/ae2/api/networking/energy/IEnergyService.java
@@ -76,16 +76,20 @@ public interface IEnergyService extends IGridService, IEnergySource {
     double injectPower(double amt, Actionable mode);
 
     /**
-     * This should be considered an estimate and not relied upon for real calculations.
+     * Outside creative/debug power mode, returns the exact power currently available from public storages that allow
+     * network extraction in the complete energy overlay, including grids connected through Quartz Fibers. Creative or
+     * debug power mode returns a fixed finite sentinel instead of inspecting storage values.
      *
-     * @return estimated available power.
+     * @return available power in the complete energy overlay
      */
     double getStoredPower();
 
     /**
-     * This should be considered an estimate and not relied upon for real calculations.
+     * Outside creative/debug power mode, returns the exact maximum power of public storages that allow network
+     * extraction in the complete energy overlay, including grids connected through Quartz Fibers. Creative or debug
+     * power mode returns the same fixed finite sentinel as {@link #getStoredPower()}.
      *
-     * @return estimated available power.
+     * @return maximum power in the complete energy overlay
      */
     double getMaxStoredPower();
 

--- a/src/main/java/ae2/api/networking/energy/PowerStorageSnapshotBuilder.java
+++ b/src/main/java/ae2/api/networking/energy/PowerStorageSnapshotBuilder.java
@@ -1,0 +1,155 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package ae2.api.networking.energy;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import ae2.api.config.AccessRestriction;
+
+/**
+ * Reusable, allocation-free snapshot of an {@link IAEPowerStorage}.
+ * <p>
+ * Implementations of {@link IAEPowerStorage#getPowerSnapshot(PowerStorageSnapshotBuilder)} must call
+ * {@link #setValues(double, double, double, double, AccessRestriction, int, boolean)} exactly once and must not retain
+ * this object. The energy cache owns the builder lifecycle and reuses one instance for cache construction, events and
+ * post-operation correction.
+ */
+public final class PowerStorageSnapshotBuilder {
+    private boolean complete;
+    private double currentPower;
+    private double maximumPower;
+    private double extractablePower;
+    private double receivablePower;
+    private AccessRestriction powerFlow;
+    private int priority;
+    private boolean publicStorage;
+
+    /**
+     * Sets every value that contributes to the overlay energy cache.
+     * <p>
+     * All power values must be finite and non-negative. Extractable power must not exceed current power. Receivable
+     * power must not exceed the currently unused part of maximum capacity.
+     */
+    public void setValues(double currentPower, double maximumPower, double extractablePower, double receivablePower,
+                          AccessRestriction powerFlow, int priority, boolean publicStorage) {
+        if (this.complete) {
+            throw new IllegalStateException("Power storage snapshot values were supplied more than once");
+        }
+
+        requirePowerValue("currentPower", currentPower);
+        requirePowerValue("maximumPower", maximumPower);
+        requirePowerValue("extractablePower", extractablePower);
+        requirePowerValue("receivablePower", receivablePower);
+        if (extractablePower > currentPower) {
+            throw new IllegalArgumentException("extractablePower must not exceed currentPower");
+        }
+        if (receivablePower > Math.max(0, maximumPower - currentPower)) {
+            throw new IllegalArgumentException("receivablePower must not exceed unused maximum capacity");
+        }
+        if (powerFlow == null) {
+            throw new IllegalArgumentException("powerFlow must not be null");
+        }
+
+        this.currentPower = currentPower;
+        this.maximumPower = maximumPower;
+        this.extractablePower = extractablePower;
+        this.receivablePower = receivablePower;
+        this.powerFlow = powerFlow;
+        this.priority = priority;
+        this.publicStorage = publicStorage;
+        this.complete = true;
+    }
+
+    @ApiStatus.Internal
+    public void reset() {
+        this.complete = false;
+        this.currentPower = 0;
+        this.maximumPower = 0;
+        this.extractablePower = 0;
+        this.receivablePower = 0;
+        this.powerFlow = null;
+        this.priority = 0;
+        this.publicStorage = false;
+    }
+
+    @ApiStatus.Internal
+    public boolean isComplete() {
+        return this.complete;
+    }
+
+    @ApiStatus.Internal
+    public double getCurrentPower() {
+        ensureComplete();
+        return this.currentPower;
+    }
+
+    @ApiStatus.Internal
+    public double getMaximumPower() {
+        ensureComplete();
+        return this.maximumPower;
+    }
+
+    @ApiStatus.Internal
+    public double getExtractablePower() {
+        ensureComplete();
+        return this.extractablePower;
+    }
+
+    @ApiStatus.Internal
+    public double getReceivablePower() {
+        ensureComplete();
+        return this.receivablePower;
+    }
+
+    @ApiStatus.Internal
+    public AccessRestriction getPowerFlow() {
+        ensureComplete();
+        return this.powerFlow;
+    }
+
+    @ApiStatus.Internal
+    public int getPriority() {
+        ensureComplete();
+        return this.priority;
+    }
+
+    @ApiStatus.Internal
+    public boolean isPublicStorage() {
+        ensureComplete();
+        return this.publicStorage;
+    }
+
+    private static void requirePowerValue(String name, double value) {
+        if (!Double.isFinite(value) || value < 0) {
+            throw new IllegalArgumentException(name + " must be finite and non-negative");
+        }
+    }
+
+    private void ensureComplete() {
+        if (!this.complete) {
+            throw new IllegalStateException("Power storage snapshot is incomplete");
+        }
+    }
+}

--- a/src/main/java/ae2/api/networking/events/GridPowerStorageChanged.java
+++ b/src/main/java/ae2/api/networking/events/GridPowerStorageChanged.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package ae2.api.networking.events;
+
+import ae2.api.networking.IGrid;
+import ae2.api.networking.energy.IAEPowerStorage;
+
+import java.util.Objects;
+
+/**
+ * Informs an {@link IGrid} that a registered {@link IAEPowerStorage} changed after it was added to the grid.
+ * <p>
+ * Value changes are refreshed incrementally through the storage's allocation-free snapshot. Routing changes discard
+ * the storage-routing cache so maximum capacity, public visibility, access restrictions and priority are evaluated
+ * lazily on the next energy operation. Adding or removing a grid node already supplies the corresponding structural
+ * notification and does not require this event.
+ */
+public final class GridPowerStorageChanged extends GridEvent {
+    /** The storage whose cached state changed. Identity, rather than {@link Object#equals(Object)}, is significant. */
+    public final IAEPowerStorage storage;
+    /** The class of cached state that changed. */
+    public final ChangeType type;
+
+    /**
+     * Creates a storage change event.
+     *
+     * @param storage storage that is already registered with the grid receiving the event
+     * @param type    whether only snapshot values or storage routing changed
+     */
+    public GridPowerStorageChanged(IAEPowerStorage storage, ChangeType type) {
+        this.storage = Objects.requireNonNull(storage, "storage");
+        this.type = Objects.requireNonNull(type, "type");
+    }
+
+    /**
+     * Identifies the minimum cache scope invalidated by a storage change.
+     */
+    public enum ChangeType {
+        /**
+         * Current power, extractable power or receivable power changed without changing maximum capacity, public
+         * visibility, access restrictions or priority. The energy service refreshes only this storage's aggregate
+         * contribution.
+         */
+        VALUES_CHANGED,
+
+        /**
+         * Maximum capacity, public visibility, access restrictions or priority changed. Maximum capacity participates
+         * in service grouping, so the energy service lazily rebuilds and reorders the complete storage-routing cache
+         * while retaining the Quartz Fiber topology cache.
+         */
+        ROUTING_CHANGED
+    }
+}

--- a/src/main/java/ae2/me/service/EnergyOverlayGrid.java
+++ b/src/main/java/ae2/me/service/EnergyOverlayGrid.java
@@ -18,101 +18,926 @@
 
 package ae2.me.service;
 
-import ae2.api.networking.energy.IPassiveEnergyGenerator;
-import ae2.core.AELog;
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+import java.util.Comparator;
+import java.util.Objects;
+
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
-import java.util.Comparator;
+import ae2.api.config.AccessRestriction;
+import ae2.api.config.Actionable;
+import ae2.api.config.PowerMultiplier;
+import ae2.api.networking.energy.IAEPowerStorage;
+import ae2.api.networking.energy.IPassiveEnergyGenerator;
+import ae2.api.networking.energy.PowerStorageSnapshotBuilder;
+import ae2.core.AELog;
+import ae2.me.energy.StoredEnergyAmount;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 
 /**
- * This class caches all energy services that are part of the overlay energy grid. This overlay grid can span multiple
- * normal {@linkplain ae2.me.Grid grids} if they are connected by {@link ae2.parts.networking.QuartzFiberPart
- * quartz fibers}.
+ * Shared lazy caches for all energy services connected through Quartz Fibers.
+ * <p>
+ * The topology cache records only connected services and owns passive-generator selection. The independently lazy
+ * {@link EnergyStorageCache} contains routed storage entries and aggregate values, so storage structure and routing
+ * changes do not require another Quartz Fiber topology walk.
  */
 class EnergyOverlayGrid {
-    /**
-     * Prefer grids with high energy storage for operations by sorting them to the front of the list.
-     */
-    private static final Comparator<EnergyService> SERVICE_COMPARATOR = Comparator
-        .comparingDouble(EnergyService::getMaxStoredPower)
-        .reversed();
+    /** Services in deterministic topology-discovery order. */
+    private final ObjectArrayList<EnergyService> energyServices;
 
-    final EnergyService[] energyServices;
+    /** Storage-group implementations in the same order as {@link #energyServices}. */
+    private final ObjectArrayList<EnergyStorageGroup> energyStorageGroups = new ObjectArrayList<>();
 
-    /**
-     * Which passive energy generator is currently active.
-     */
+    /** Which passive energy generator is currently active. */
     @Nullable
     private IPassiveEnergyGenerator currentPassiveGenerator;
 
-    private EnergyOverlayGrid(EnergyService[] energyServices) {
+    /** Null until a non-creative energy operation requests storage values or routing. */
+    @Nullable
+    private EnergyStorageCache storageCache;
+
+    /** Number of connected services that currently contain at least one creative energy cell. */
+    private int creativePowerServiceCount;
+
+    /** Changes whenever an in-flight storage-cache build must not be installed. */
+    private long storageCacheRevision;
+
+    /** Guards against storage callbacks recursively requesting another storage-cache build. */
+    private boolean storageCacheBuildInProgress;
+
+    /** Cleared before this topology is detached from its services. */
+    private boolean valid = true;
+
+    private EnergyOverlayGrid(ObjectArrayList<EnergyService> energyServices) {
         this.energyServices = energyServices;
+        int serviceCount = energyServices.size();
+        for (int i = 0; i < serviceCount; i++) {
+            var service = energyServices.get(i);
+            this.energyStorageGroups.add(service.getEnergyStorageGroup());
+            if (service.hasCreativeEnergyCell()) {
+                this.creativePowerServiceCount++;
+            }
+        }
     }
 
     /**
-     * Build a new overlay energy grid by discovering all accessible {@linkplain EnergyService energy services} starting
-     * with the given grid.
+     * Builds and shares a topology cache by discovering all services reachable from {@code startingService}.
      */
     static void buildCache(EnergyService startingService) {
         var connectedServices = new ReferenceOpenHashSet<EnergyService>();
+        var pendingServices = new ObjectArrayList<EnergyService>();
+        var discoveredServices = new ObjectArrayList<EnergyService>();
+        pendingServices.add(startingService);
 
-        // Walk graph
-        var services = new ObjectArrayList<EnergyService>();
-        services.add(startingService);
+        while (!pendingServices.isEmpty()) {
+            var service = pendingServices.pop();
+            if (!connectedServices.add(service)) {
+                continue;
+            }
 
-        while (!services.isEmpty()) {
-            var service = services.pop();
-
-            // If the service was not already processed, add it and also discover other services
-            // reachable via its grid.
-            if (connectedServices.add(service)) {
-                for (var provider : service.getOverlayGridConnections()) {
-                    services.addAll(provider.connectedEnergyServices());
-                }
+            discoveredServices.add(service);
+            for (var connection : service.getOverlayGridConnections()) {
+                pendingServices.addAll(connection.connectedEnergyServices());
             }
         }
 
-        // Sort services by capacity
-        EnergyService[] sortedServices = connectedServices.toArray(EnergyService[]::new);
-        Arrays.sort(sortedServices, SERVICE_COMPARATOR);
-        var overlayGrid = new EnergyOverlayGrid(sortedServices);
-
-        // Associate all grids that are part of the overlay grid with this instance
-        for (var service : sortedServices) {
-            // A previous overlay grid should have been invalidated before building a new one
-            if (service.overlayGrid != null) {
+        var overlayGrid = new EnergyOverlayGrid(discoveredServices);
+        int serviceCount = discoveredServices.size();
+        for (int i = 0; i < serviceCount; i++) {
+            var service = discoveredServices.get(i);
+            var previousOverlay = service.overlayGrid;
+            if (previousOverlay != null) {
                 AELog.error("Grid %s energy service already has a power graph assigned to it!", service.grid);
+                previousOverlay.invalidate();
             }
+        }
 
-            service.overlayGrid = overlayGrid;
+        for (int i = 0; i < serviceCount; i++) {
+            discoveredServices.get(i).overlayGrid = overlayGrid;
         }
     }
 
+    /**
+     * Invalidates this topology and detaches only services that still point at this instance.
+     */
     void invalidate() {
-        currentPassiveGenerator = null;
-        for (var service : energyServices) {
-            service.overlayGrid = null;
+        if (!this.valid) {
+            return;
         }
+
+        this.valid = false;
+        this.currentPassiveGenerator = null;
+        invalidateStorageCache();
+
+        int serviceCount = this.energyServices.size();
+        for (int i = 0; i < serviceCount; i++) {
+            var service = this.energyServices.get(i);
+            if (service.overlayGrid == this) {
+                service.overlayGrid = null;
+            }
+        }
+    }
+
+    /**
+     * @return whether this topology is still the cache attached to {@code service}
+     */
+    boolean isAttachedTo(EnergyService service) {
+        return this.valid && service.overlayGrid == this;
+    }
+
+    /**
+     * Discards storage values and routing while retaining topology and passive-generator state.
+     */
+    void invalidateStorageCache() {
+        this.storageCacheRevision++;
+        var cache = this.storageCache;
+        this.storageCache = null;
+        if (cache != null) {
+            cache.invalidate();
+        }
+    }
+
+    /**
+     * Incrementally refreshes one storage if the storage cache has already been built.
+     */
+    void refreshStorageValues(EnergyStorageGroup service, IAEPowerStorage storage) {
+        var cache = this.storageCache;
+        if (cache != null && this.valid) {
+            cache.refreshStorage(service, storage);
+        } else if (this.storageCacheBuildInProgress) {
+            this.storageCacheRevision++;
+        }
+    }
+
+    double getStoredPower(EnergyService requestingService) {
+        var cache = getStorageCache(requestingService);
+        return isCurrent(cache) ? cache.getStoredPower() : 0;
+    }
+
+    double getMaximumPower(EnergyService requestingService) {
+        var cache = getStorageCache(requestingService);
+        return isCurrent(cache) ? cache.getMaximumPower() : 0;
+    }
+
+    double getEnergyDemand(EnergyService requestingService, double maximumDemand) {
+        var cache = getStorageCache(requestingService);
+        return isCurrent(cache) ? cache.getEnergyDemand(maximumDemand) : 0;
+    }
+
+    double extractPower(EnergyService requestingService, double amount, Actionable mode) {
+        if (amount < StoredEnergyAmount.MIN_AMOUNT) {
+            return 0;
+        }
+        var cache = getStorageCache(requestingService);
+        return isCurrent(cache) ? cache.extractPower(amount, mode) : 0;
+    }
+
+    double injectPower(EnergyService requestingService, double amount, Actionable mode) {
+        if (amount < StoredEnergyAmount.MIN_AMOUNT) {
+            return amount;
+        }
+        var cache = getStorageCache(requestingService);
+        return isCurrent(cache) ? cache.injectPower(amount, mode) : amount;
     }
 
     @Nullable
-    public IPassiveEnergyGenerator getCurrentPassiveGenerator() {
-        return currentPassiveGenerator;
+    IPassiveEnergyGenerator getCurrentPassiveGenerator() {
+        return this.currentPassiveGenerator;
     }
 
-    public void setCurrentPassiveGenerator(@Nullable IPassiveEnergyGenerator currentPassiveGenerator) {
+    void setCurrentPassiveGenerator(@Nullable IPassiveEnergyGenerator currentPassiveGenerator) {
         this.currentPassiveGenerator = currentPassiveGenerator;
     }
 
-    public boolean hasCreativePowerSource() {
-        for (var service : energyServices) {
-            if (service.hasCreativeEnergyCell()) {
-                return true;
+    boolean hasCreativePowerSource() {
+        return this.creativePowerServiceCount > 0;
+    }
+
+    void addCreativePowerService() {
+        if (this.creativePowerServiceCount == Integer.MAX_VALUE) {
+            throw new IllegalStateException("Creative power service count overflow");
+        }
+        this.creativePowerServiceCount++;
+    }
+
+    void removeCreativePowerService() {
+        if (this.creativePowerServiceCount <= 0) {
+            throw new IllegalStateException("Cannot remove a creative power service from an empty topology count");
+        }
+        this.creativePowerServiceCount--;
+    }
+
+    private EnergyStorageCache getStorageCache(EnergyService requestingService) {
+        var cache = this.storageCache;
+        if (cache != null && cache.isValid()) {
+            return cache;
+        }
+        this.storageCache = null;
+
+        if (this.storageCacheBuildInProgress) {
+            throw new IllegalStateException("Power storage snapshot recursively requested the overlay storage cache");
+        }
+
+        long buildRevision = this.storageCacheRevision;
+        this.storageCacheBuildInProgress = true;
+        try {
+            cache = new EnergyStorageCache(this.energyStorageGroups);
+        } finally {
+            this.storageCacheBuildInProgress = false;
+        }
+
+        if (isAttachedTo(requestingService) && this.storageCacheRevision == buildRevision) {
+            this.storageCache = cache;
+        } else {
+            cache.invalidate();
+        }
+        return cache;
+    }
+
+    private boolean isCurrent(EnergyStorageCache cache) {
+        return this.valid && cache.isValid() && this.storageCache == cache;
+    }
+}
+
+/** Per-service power transferred by routed storage operations since the last statistics sample. */
+final class EnergyPowerStatistics {
+    private double powerExtraction;
+    private double powerInjection;
+
+    void recordPowerExtraction(double amount) {
+        this.powerExtraction = addFinite(this.powerExtraction, amount);
+    }
+
+    void recordPowerInjection(double amount) {
+        this.powerInjection = addFinite(this.powerInjection, amount);
+    }
+
+    double getPowerExtraction() {
+        return this.powerExtraction;
+    }
+
+    double getPowerInjection() {
+        return this.powerInjection;
+    }
+
+    void reset() {
+        this.powerExtraction = 0;
+        this.powerInjection = 0;
+    }
+
+    private static double addFinite(double current, double amount) {
+        double result = current + amount;
+        return Double.isFinite(result) ? result : Double.MAX_VALUE;
+    }
+}
+
+/** One service's production storage registrations, identity lookup and immediate tick statistics. */
+final class EnergyStorageGroup {
+    private final ObjectArrayList<EnergyStorageRegistration> registeredStorages = new ObjectArrayList<>();
+    private final Reference2ObjectMap<IAEPowerStorage, EnergyStorageRegistration> registeredStorageLookup =
+        new Reference2ObjectOpenHashMap<>();
+    private final EnergyPowerStatistics powerStatistics;
+    private long nextStorageRegistrationSequence;
+
+    EnergyStorageGroup(EnergyPowerStatistics powerStatistics) {
+        this.powerStatistics = Objects.requireNonNull(powerStatistics, "powerStatistics");
+    }
+
+    void register(IAEPowerStorage storage) {
+        var existingRegistration = this.registeredStorageLookup.get(storage);
+        if (existingRegistration != null) {
+            if (existingRegistration.referenceCount == Integer.MAX_VALUE) {
+                throw new IllegalStateException("Power storage registration reference count overflow");
+            }
+            existingRegistration.referenceCount++;
+            return;
+        }
+
+        if (this.nextStorageRegistrationSequence == Long.MAX_VALUE) {
+            throw new IllegalStateException("Power storage registration sequence overflow");
+        }
+        var registration = new EnergyStorageRegistration(storage, this.nextStorageRegistrationSequence++);
+        this.registeredStorageLookup.put(storage, registration);
+        this.registeredStorages.add(registration);
+    }
+
+    void unregister(IAEPowerStorage storage) {
+        var registration = this.registeredStorageLookup.get(storage);
+        if (registration == null || registration.referenceCount <= 0) {
+            throw new IllegalStateException("Cannot remove an unregistered power storage");
+        }
+
+        registration.referenceCount--;
+        if (registration.referenceCount > 0) {
+            return;
+        }
+
+        this.registeredStorageLookup.remove(storage);
+        int registrationCount = this.registeredStorages.size();
+        for (int i = 0; i < registrationCount; i++) {
+            if (this.registeredStorages.get(i) == registration) {
+                this.registeredStorages.remove(i);
+                return;
             }
         }
-        return false;
+        throw new IllegalStateException("Power storage identity lookup and registration order diverged");
+    }
+
+    boolean contains(IAEPowerStorage storage) {
+        return this.registeredStorageLookup.containsKey(storage);
+    }
+
+    ObjectArrayList<EnergyStorageRegistration> registrations() {
+        return this.registeredStorages;
+    }
+
+    void recordPowerExtraction(double amount) {
+        this.powerStatistics.recordPowerExtraction(amount);
+    }
+
+    void recordPowerInjection(double amount) {
+        this.powerStatistics.recordPowerInjection(amount);
+    }
+}
+
+/** Identity registration retained across lazy storage-cache generations. */
+final class EnergyStorageRegistration {
+    /** Storage identity registered by a node service. */
+    final IAEPowerStorage storage;
+    /** Monotonic service-local sequence used to stabilize equal-priority ordering. */
+    final long registrationSequence;
+    /** Number of node registrations that expose the same storage identity. */
+    int referenceCount = 1;
+
+    EnergyStorageRegistration(IAEPowerStorage storage, long registrationSequence) {
+        this.storage = Objects.requireNonNull(storage, "storage");
+        if (registrationSequence < 0) {
+            throw new IllegalArgumentException("registrationSequence must be non-negative");
+        }
+        this.registrationSequence = registrationSequence;
+    }
+}
+
+/**
+ * Directly constructible package-private core for storage snapshots, aggregate accounting and routed hot traversal.
+ * <p>
+ * A cache instance is one immutable routing generation. Snapshot values remain mutable and are corrected by absolute
+ * reads after every real storage call. Invalidating a generation makes in-flight operations stop before touching
+ * another entry.
+ */
+final class EnergyStorageCache {
+    private static final Comparator<ServiceStorageCache> SERVICE_CAPACITY_ORDER = (left, right) -> {
+        int capacityComparison = Double.compare(right.maximumPower.value(), left.maximumPower.value());
+        return capacityComparison != 0
+            ? capacityComparison
+            : Integer.compare(left.topologyIndex, right.topologyIndex);
+    };
+
+    private static final Comparator<StorageEntry> EXTRACTION_ORDER = (left, right) -> {
+        int priorityComparison = Integer.compare(right.priority, left.priority);
+        return priorityComparison != 0
+            ? priorityComparison
+            : Long.compare(left.registrationSequence, right.registrationSequence);
+    };
+
+    private static final Comparator<StorageEntry> INSERTION_ORDER = Comparator.comparingInt((StorageEntry left) -> left.priority).thenComparingLong(left -> left.registrationSequence);
+
+    private final ObjectArrayList<ServiceStorageCache> serviceGroups = new ObjectArrayList<>();
+    private final Reference2ObjectMap<IAEPowerStorage, StorageEntry> entriesByStorage =
+        new Reference2ObjectOpenHashMap<>();
+    private final PowerStorageSnapshotBuilder snapshotBuilder = new PowerStorageSnapshotBuilder();
+
+    @Nullable
+    private StorageEntry activeEntry;
+    private boolean valid = true;
+    private boolean snapshotReadInProgress;
+    private final CompensatedPowerSum storedPower = new CompensatedPowerSum();
+    private final CompensatedPowerSum maximumPower = new CompensatedPowerSum();
+    private final CompensatedPowerSum extractablePower = new CompensatedPowerSum();
+    private final CompensatedPowerSum energyDemand = new CompensatedPowerSum();
+
+    /**
+     * Builds a routing generation from service groups in topology-discovery order.
+     *
+     * @param groups real storage groups; the constructor reads registrations immediately and does not retain this list
+     */
+    EnergyStorageCache(ObjectArrayList<EnergyStorageGroup> groups) {
+        int serviceCount = groups.size();
+        for (int i = 0; i < serviceCount; i++) {
+            var group = new ServiceStorageCache(this, groups.get(i), i);
+            this.serviceGroups.add(group);
+            buildServiceGroup(group);
+        }
+
+        this.serviceGroups.sort(SERVICE_CAPACITY_ORDER);
+    }
+
+    boolean isValid() {
+        return this.valid;
+    }
+
+    void invalidate() {
+        this.valid = false;
+    }
+
+    double getStoredPower() {
+        return this.valid ? this.storedPower.value() : 0;
+    }
+
+    double getMaximumPower() {
+        return this.valid ? this.maximumPower.value() : 0;
+    }
+
+    double getEnergyDemand(double maximumDemand) {
+        requirePowerAmount(maximumDemand, "maximumDemand");
+        return this.valid ? Math.min(maximumDemand, this.energyDemand.value()) : 0;
+    }
+
+    double extractPower(double amount, Actionable mode) {
+        requirePowerAmount(amount, "amount");
+        Objects.requireNonNull(mode, "mode");
+        if (!this.valid || amount < StoredEnergyAmount.MIN_AMOUNT) {
+            return 0;
+        }
+
+        double extractionTarget = Math.min(amount, this.extractablePower.value());
+        if (mode == Actionable.SIMULATE || extractionTarget <= 0) {
+            return extractionTarget;
+        }
+
+        double extractedPower = 0;
+        int groupCount = this.serviceGroups.size();
+        for (int groupIndex = 0; groupIndex < groupCount && extractedPower < extractionTarget; groupIndex++) {
+            if (!this.valid) {
+                break;
+            }
+
+            double remainingPower = extractionTarget - extractedPower;
+            if (remainingPower < StoredEnergyAmount.MIN_AMOUNT) {
+                break;
+            }
+
+            var group = this.serviceGroups.get(groupIndex);
+            double groupTarget = Math.min(remainingPower, group.extractablePower.value());
+            double groupExtracted = 0;
+            int entryCount = group.extractionOrder.size();
+            for (int entryIndex = 0; entryIndex < entryCount && groupExtracted < groupTarget; entryIndex++) {
+                if (!this.valid) {
+                    return extractedPower;
+                }
+
+                double groupRemainingPower = groupTarget - groupExtracted;
+                if (groupRemainingPower < StoredEnergyAmount.MIN_AMOUNT) {
+                    break;
+                }
+
+                var entry = group.extractionOrder.get(entryIndex);
+                double entryTarget = Math.min(groupRemainingPower, entry.extractablePower);
+                if (entryTarget < StoredEnergyAmount.MIN_AMOUNT) {
+                    continue;
+                }
+
+                double extracted = callExtract(entry, entryTarget);
+                groupExtracted += extracted;
+                extractedPower += extracted;
+            }
+        }
+
+        return Math.min(extractedPower, extractionTarget);
+    }
+
+    double injectPower(double amount, Actionable mode) {
+        requirePowerAmount(amount, "amount");
+        Objects.requireNonNull(mode, "mode");
+        if (!this.valid || amount < StoredEnergyAmount.MIN_AMOUNT) {
+            return amount;
+        }
+
+        double insertionTarget = Math.min(amount, this.energyDemand.value());
+        if (mode == Actionable.SIMULATE || insertionTarget <= 0) {
+            return amount - insertionTarget;
+        }
+
+        double injectedPower = 0;
+        int groupCount = this.serviceGroups.size();
+        for (int groupIndex = 0; groupIndex < groupCount && injectedPower < insertionTarget; groupIndex++) {
+            if (!this.valid) {
+                break;
+            }
+
+            double remainingPower = insertionTarget - injectedPower;
+            if (remainingPower < StoredEnergyAmount.MIN_AMOUNT) {
+                break;
+            }
+
+            var group = this.serviceGroups.get(groupIndex);
+            double groupTarget = Math.min(remainingPower, group.energyDemand.value());
+            double groupInjected = 0;
+            int entryCount = group.insertionOrder.size();
+            for (int entryIndex = 0; entryIndex < entryCount && groupInjected < groupTarget; entryIndex++) {
+                if (!this.valid) {
+                    return amount - injectedPower;
+                }
+
+                double groupRemainingPower = groupTarget - groupInjected;
+                if (groupRemainingPower < StoredEnergyAmount.MIN_AMOUNT) {
+                    break;
+                }
+
+                var entry = group.insertionOrder.get(entryIndex);
+                double entryTarget = Math.min(groupRemainingPower, entry.energyDemand);
+                if (entryTarget < StoredEnergyAmount.MIN_AMOUNT) {
+                    continue;
+                }
+
+                double injected = callInject(entry, entryTarget);
+                groupInjected += injected;
+                injectedPower += injected;
+            }
+        }
+
+        return amount - Math.min(injectedPower, insertionTarget);
+    }
+
+    void refreshStorage(EnergyStorageGroup service, IAEPowerStorage storage) {
+        if (!this.valid) {
+            return;
+        }
+
+        var entry = this.entriesByStorage.get(storage);
+        if (entry == null) {
+            if (service.contains(storage)) {
+                invalidate();
+            } else {
+                AELog.warn("Ignoring a power-storage value event for unregistered storage %s.",
+                    describeStorage(storage));
+            }
+            return;
+        }
+
+        if (entry.group.service != service) {
+            AELog.error("Power-storage value event for %s was posted to a different energy service.",
+                describeStorage(storage));
+            return;
+        }
+
+        if (entry == this.activeEntry) {
+            return;
+        }
+
+        readStorageSnapshot(entry);
+    }
+
+    private static void requirePowerAmount(double amount, String name) {
+        if (!Double.isFinite(amount) || amount < 0) {
+            throw new IllegalArgumentException(name + " must be finite and non-negative");
+        }
+    }
+
+    private void buildServiceGroup(ServiceStorageCache group) {
+        var registrations = group.service.registrations();
+        int registrationCount = registrations.size();
+        for (int i = 0; i < registrationCount; i++) {
+            addStorage(group, registrations.get(i));
+        }
+
+        group.extractionOrder.sort(EXTRACTION_ORDER);
+        group.insertionOrder.sort(INSERTION_ORDER);
+    }
+
+    private void addStorage(ServiceStorageCache group, EnergyStorageRegistration registration) {
+        var storage = registration.storage;
+        var existingEntry = this.entriesByStorage.get(storage);
+        if (existingEntry != null) {
+            AELog.error("Power storage %s is registered with multiple services in one energy overlay; "
+                + "the later registration is ignored.", describeStorage(storage));
+            return;
+        }
+
+        if (!collectStorageSnapshot(storage)) {
+            return;
+        }
+
+        var powerFlow = this.snapshotBuilder.getPowerFlow();
+        var entry = new StorageEntry(group, storage, registration.registrationSequence,
+            this.snapshotBuilder.getMaximumPower(), this.snapshotBuilder.getPriority(), powerFlow,
+            this.snapshotBuilder.isPublicStorage());
+        this.entriesByStorage.put(storage, entry);
+        if (entry.publicStorage && entry.allowExtraction) {
+            group.extractionOrder.add(entry);
+        }
+        if (entry.publicStorage && entry.allowInsertion) {
+            group.insertionOrder.add(entry);
+        }
+        applyCollectedSnapshot(entry);
+    }
+
+    private void readStorageSnapshot(StorageEntry entry) {
+        if (this.snapshotReadInProgress) {
+            AELog.error("Power storage %s emitted a reentrant event while its snapshot was being read; "
+                + "the reentrant refresh was ignored.", describeStorage(entry.storage));
+            return;
+        }
+
+        if (!collectStorageSnapshot(entry.storage)) {
+            entry.replaceSnapshot(0, 0, 0, 0);
+            return;
+        }
+
+        if (Double.compare(this.snapshotBuilder.getMaximumPower(), entry.routingMaximumPower) != 0
+            || this.snapshotBuilder.isPublicStorage() != entry.publicStorage
+            || this.snapshotBuilder.getPowerFlow() != entry.powerFlow
+            || this.snapshotBuilder.getPriority() != entry.priority) {
+            AELog.error("Power storage %s changed maximum capacity, public visibility, access restrictions or "
+                + "priority without a ROUTING_CHANGED event; the storage cache is invalidated.",
+                describeStorage(entry.storage));
+            invalidate();
+            return;
+        }
+
+        applyCollectedSnapshot(entry);
+    }
+
+    private boolean collectStorageSnapshot(IAEPowerStorage storage) {
+        this.snapshotReadInProgress = true;
+        this.snapshotBuilder.reset();
+        try {
+            storage.getPowerSnapshot(this.snapshotBuilder);
+            if (!this.snapshotBuilder.isComplete()) {
+                throw new IllegalStateException("Power storage did not supply a complete snapshot");
+            }
+            return true;
+        } catch (RuntimeException exception) {
+            AELog.error(exception, "Invalid power snapshot from storage " + describeStorage(storage)
+                + "; its cached contribution is isolated until a valid refresh.");
+            return false;
+        } finally {
+            this.snapshotReadInProgress = false;
+        }
+    }
+
+    private void applyCollectedSnapshot(StorageEntry entry) {
+        if (!entry.publicStorage) {
+            entry.replaceSnapshot(0, 0, 0, 0);
+            return;
+        }
+
+        entry.replaceSnapshot(
+            entry.allowExtraction ? this.snapshotBuilder.getCurrentPower() : 0,
+            entry.allowExtraction ? this.snapshotBuilder.getMaximumPower() : 0,
+            entry.allowExtraction ? usableOperationPower(this.snapshotBuilder.getExtractablePower()) : 0,
+            entry.allowInsertion ? usableOperationPower(this.snapshotBuilder.getReceivablePower()) : 0);
+    }
+
+    private double callExtract(StorageEntry entry, double amount) {
+        beginActiveOperation(entry);
+        double extracted = 0;
+        try {
+            double result = entry.storage.extractAEPower(amount, Actionable.MODULATE, PowerMultiplier.ONE);
+            extracted = validateExtractResult(entry.storage, result, amount);
+        } catch (RuntimeException exception) {
+            AELog.error(exception, "Power extraction failed for storage " + describeStorage(entry.storage));
+        } finally {
+            finishActiveOperation(entry);
+        }
+
+        if (extracted > 0) {
+            entry.group.service.recordPowerExtraction(extracted);
+        }
+        return extracted;
+    }
+
+    private double callInject(StorageEntry entry, double amount) {
+        beginActiveOperation(entry);
+        double injected = 0;
+        try {
+            double overflow = entry.storage.injectAEPower(amount, Actionable.MODULATE);
+            injected = amount - validateOverflowResult(entry.storage, overflow, amount);
+        } catch (RuntimeException exception) {
+            AELog.error(exception, "Power injection failed for storage " + describeStorage(entry.storage));
+        } finally {
+            finishActiveOperation(entry);
+        }
+
+        if (injected > 0) {
+            entry.group.service.recordPowerInjection(injected);
+        }
+        return injected;
+    }
+
+    private void beginActiveOperation(StorageEntry entry) {
+        if (this.activeEntry != null) {
+            throw new IllegalStateException("Power storage operation reentered the overlay energy cache");
+        }
+        this.activeEntry = entry;
+    }
+
+    private void finishActiveOperation(StorageEntry entry) {
+        if (this.activeEntry != entry) {
+            throw new IllegalStateException("Power storage operation active-entry state diverged");
+        }
+
+        this.activeEntry = null;
+        if (this.valid) {
+            readStorageSnapshot(entry);
+        }
+    }
+
+    private static double usableOperationPower(double amount) {
+        return amount < StoredEnergyAmount.MIN_AMOUNT ? 0 : amount;
+    }
+
+    private static double validateExtractResult(IAEPowerStorage storage, double result, double requested) {
+        if (Double.isNaN(result) || result < 0) {
+            AELog.error("Power storage %s returned invalid extracted power %s.", describeStorage(storage), result);
+            return 0;
+        }
+        if (!Double.isFinite(result) || result > requested) {
+            AELog.error("Power storage %s returned extracted power %s above the requested %s.",
+                describeStorage(storage), result, requested);
+            return requested;
+        }
+        return result;
+    }
+
+    private static double validateOverflowResult(IAEPowerStorage storage, double result, double requested) {
+        if (Double.isNaN(result) || !Double.isFinite(result) || result > requested) {
+            AELog.error("Power storage %s returned invalid injection overflow %s for requested power %s.",
+                describeStorage(storage), result, requested);
+            return requested;
+        }
+        if (result < 0) {
+            AELog.error("Power storage %s returned negative injection overflow %s.", describeStorage(storage), result);
+            return 0;
+        }
+        return result;
+    }
+
+    private void replaceSnapshotContribution(StorageEntry entry, double storedPower, double maximumPower,
+                                             double extractablePower, double energyDemand) {
+        var group = entry.group;
+        group.storedPower.replace(entry.storedPower, storedPower);
+        group.maximumPower.replace(entry.maximumPower, maximumPower);
+        group.extractablePower.replace(entry.extractablePower, extractablePower);
+        group.energyDemand.replace(entry.energyDemand, energyDemand);
+
+        this.storedPower.replace(entry.storedPower, storedPower);
+        this.maximumPower.replace(entry.maximumPower, maximumPower);
+        this.extractablePower.replace(entry.extractablePower, extractablePower);
+        this.energyDemand.replace(entry.energyDemand, energyDemand);
+    }
+
+    private static String describeStorage(IAEPowerStorage storage) {
+        return storage.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(storage));
+    }
+
+    /** Storage entries belonging to one service, kept contiguous in overlay operation order. */
+    private static final class ServiceStorageCache {
+        private final EnergyStorageCache owner;
+        private final EnergyStorageGroup service;
+        private final int topologyIndex;
+        private final ObjectArrayList<StorageEntry> extractionOrder = new ObjectArrayList<>();
+        private final ObjectArrayList<StorageEntry> insertionOrder = new ObjectArrayList<>();
+
+        private final CompensatedPowerSum storedPower = new CompensatedPowerSum();
+        private final CompensatedPowerSum maximumPower = new CompensatedPowerSum();
+        private final CompensatedPowerSum extractablePower = new CompensatedPowerSum();
+        private final CompensatedPowerSum energyDemand = new CompensatedPowerSum();
+
+        private ServiceStorageCache(EnergyStorageCache owner, EnergyStorageGroup service, int topologyIndex) {
+            this.owner = owner;
+            this.service = service;
+            this.topologyIndex = topologyIndex;
+        }
+    }
+
+    /** One identity-addressed storage contribution in a storage-cache generation. */
+    private static final class StorageEntry {
+        private final ServiceStorageCache group;
+        private final IAEPowerStorage storage;
+        private final long registrationSequence;
+        private final double routingMaximumPower;
+        private final int priority;
+        private final AccessRestriction powerFlow;
+        private final boolean publicStorage;
+        private final boolean allowExtraction;
+        private final boolean allowInsertion;
+
+        private double storedPower;
+        private double maximumPower;
+        private double extractablePower;
+        private double energyDemand;
+
+        private StorageEntry(ServiceStorageCache group, IAEPowerStorage storage, long registrationSequence,
+                             double routingMaximumPower, int priority, AccessRestriction powerFlow,
+                             boolean publicStorage) {
+            this.group = group;
+            this.storage = storage;
+            this.registrationSequence = registrationSequence;
+            this.routingMaximumPower = routingMaximumPower;
+            this.priority = priority;
+            this.powerFlow = powerFlow;
+            this.publicStorage = publicStorage;
+            this.allowExtraction = powerFlow.isAllowExtraction();
+            this.allowInsertion = powerFlow.isAllowInsertion();
+        }
+
+        private void replaceSnapshot(double storedPower, double maximumPower, double extractablePower,
+                                     double energyDemand) {
+            this.group.owner.replaceSnapshotContribution(this, storedPower, maximumPower, extractablePower,
+                energyDemand);
+            this.storedPower = storedPower;
+            this.maximumPower = maximumPower;
+            this.extractablePower = extractablePower;
+            this.energyDemand = energyDemand;
+        }
+    }
+
+    /**
+     * Allocation-free scaled double-double accumulator. Scaling keeps overflow recoverable while the low component
+     * preserves contributions that would be rounded away by the high component.
+     */
+    private static final class CompensatedPowerSum {
+        private boolean initialized;
+        private int scaleExponent;
+        private double high;
+        private double low;
+
+        private void replace(double previous, double current) {
+            add(-previous);
+            add(current);
+        }
+
+        private void add(double value) {
+            if (value == 0) {
+                return;
+            }
+
+            int valueExponent = Math.getExponent(Math.abs(value));
+            if (!this.initialized) {
+                this.initialized = true;
+                this.scaleExponent = valueExponent;
+                this.high = Math.scalb(value, -valueExponent);
+                this.low = 0;
+                return;
+            }
+
+            if (valueExponent > this.scaleExponent) {
+                int shift = this.scaleExponent - valueExponent;
+                this.high = Math.scalb(this.high, shift);
+                this.low = Math.scalb(this.low, shift);
+                this.scaleExponent = valueExponent;
+            }
+
+            addScaled(Math.scalb(value, -this.scaleExponent));
+            normalizeScale();
+        }
+
+        private void addScaled(double value) {
+            double sum = this.high + value;
+            double virtualValue = sum - this.high;
+            double error = (this.high - (sum - virtualValue)) + (value - virtualValue);
+            double correctedLow = this.low + error;
+            double correctedHigh = sum + correctedLow;
+            this.low = correctedLow - (correctedHigh - sum);
+            this.high = correctedHigh;
+        }
+
+        private void normalizeScale() {
+            double magnitude = Math.max(Math.abs(this.high), Math.abs(this.low));
+            if (magnitude == 0) {
+                this.initialized = false;
+                this.scaleExponent = 0;
+                this.high = 0;
+                this.low = 0;
+                return;
+            }
+
+            int shift = Math.getExponent(magnitude);
+            if (shift != 0) {
+                this.high = Math.scalb(this.high, -shift);
+                this.low = Math.scalb(this.low, -shift);
+                this.scaleExponent += shift;
+            }
+        }
+
+        private double value() {
+            if (!this.initialized) {
+                return 0;
+            }
+
+            double significand = this.high + this.low;
+            if (significand <= 0) {
+                return 0;
+            }
+            if (this.scaleExponent > Double.MAX_EXPONENT) {
+                return Double.MAX_VALUE;
+            }
+
+            double result = Math.scalb(significand, this.scaleExponent);
+            return Double.isFinite(result) ? result : Double.MAX_VALUE;
+        }
     }
 }

--- a/src/main/java/ae2/me/service/EnergyService.java
+++ b/src/main/java/ae2/me/service/EnergyService.java
@@ -18,7 +18,6 @@
 
 package ae2.me.service;
 
-import ae2.api.config.AccessRestriction;
 import ae2.api.config.Actionable;
 import ae2.api.config.PowerMultiplier;
 import ae2.api.networking.GridHelper;
@@ -33,6 +32,7 @@ import ae2.api.networking.energy.IEnergyWatcherNode;
 import ae2.api.networking.energy.IPassiveEnergyGenerator;
 import ae2.api.networking.events.GridPowerIdleChange;
 import ae2.api.networking.events.GridPowerStatusChange;
+import ae2.api.networking.events.GridPowerStorageChanged;
 import ae2.api.networking.events.GridPowerStorageStateChanged;
 import ae2.api.networking.pathing.IPathingService;
 import ae2.core.AEConfig;
@@ -47,46 +47,36 @@ import ae2.tile.networking.TileCreativeEnergyCell;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
-import it.unimi.dsi.fastutil.objects.ObjectRBTreeSet;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import net.minecraft.nbt.NBTTagCompound;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.Iterator;
 import java.util.NavigableSet;
 import java.util.Objects;
-import java.util.SortedSet;
 import java.util.TreeSet;
 
 public class EnergyService implements IEnergyService, IGridServiceProvider {
     private static final String TAG_STORED_ENERGY = "e";
     private static final int NBT_DOUBLE = 6;
-    private static final Comparator<IAEPowerStorage> COMPARATOR_HIGHEST_PRIORITY_FIRST = (o1, o2) -> {
-        final int cmp = Integer.compare(o2.getPriority(), o1.getPriority());
-        return cmp != 0 ? cmp : Integer.compare(System.identityHashCode(o2), System.identityHashCode(o1));
-    };
-    private static final Comparator<IAEPowerStorage> COMPARATOR_LOWEST_PRIORITY_FIRST = (o1,
-                                                                                         o2) -> -COMPARATOR_HIGHEST_PRIORITY_FIRST.compare(o1, o2);
+    private static final double CREATIVE_POWER = (double) Long.MAX_VALUE / 10000;
 
     static {
         GridHelper.addGridServiceEventHandler(GridPowerIdleChange.class, IEnergyService.class,
             (service, event) -> ((EnergyService) service).nodeIdlePowerChangeHandler(event));
         GridHelper.addGridServiceEventHandler(GridPowerStorageStateChanged.class, IEnergyService.class,
             (service, event) -> ((EnergyService) service).storagePowerChangeHandler(event));
+        GridHelper.addGridServiceEventHandler(GridPowerStorageChanged.class, IEnergyService.class,
+            (service, event) -> ((EnergyService) service).storagePowerChangeHandler(event));
     }
 
     final Grid grid;
     private final NavigableSet<EnergyThreshold> interests = new TreeSet<>();
-    // Should only be modified from the add/remove methods below to guard against
-    private final SortedSet<IAEPowerStorage> providers = new ObjectRBTreeSet<>(COMPARATOR_HIGHEST_PRIORITY_FIRST);
-    // Should only be modified from the add/remove methods below to guard against
-    private final SortedSet<IAEPowerStorage> requesters = new ObjectRBTreeSet<>(COMPARATOR_LOWEST_PRIORITY_FIRST);
+    private final EnergyPowerStatistics energyPowerStatistics = new EnergyPowerStatistics();
+    private final EnergyStorageGroup energyStorageGroup = new EnergyStorageGroup(this.energyPowerStatistics);
     private final Multiset<IEnergyOverlayGridConnection> overlayGridConnections = HashMultiset.create();
     private final Reference2ObjectMap<IGridNode, IEnergyWatcher> watchers = new Reference2ObjectOpenHashMap<>();
     private final GridEnergyStorage localStorage;
@@ -100,24 +90,12 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
      * {@linkplain ae2.parts.networking.QuartzFiberPart quartz fibers}.
      */
     EnergyOverlayGrid overlayGrid = null;
-    // Used to track whether an extraction is currently in progress, to fail fast
-    private boolean ongoingExtractOperation = false;
-    // Used to track whether an injection is currently in progress, to fail fast
-    private boolean ongoingInjectOperation = false;
-    /**
-     * estimated power available.
-     */
-    private int availableTicksSinceUpdate = 0;
-    private double globalAvailablePower = 0;
-    private double providerPowerSum;
     /**
      * idle draw.
      */
     private double drainPerTick = 0;
     private double avgDrainPerTick = 0;
     private double avgInjectionPerTick = 0;
-    private double tickDrainPerTick = 0;
-    private double tickInjectionPerTick = 0;
     /**
      * power status
      */
@@ -131,8 +109,7 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
         this.grid = (Grid) g;
         this.pgc = (PathingService) pgc;
         this.localStorage = new GridEnergyStorage(grid);
-        this.requesters.add(this.localStorage);
-        this.providers.add(this.localStorage);
+        this.energyStorageGroup.register(this.localStorage);
     }
 
     public void nodeIdlePowerChangeHandler(GridPowerIdleChange ev) {
@@ -147,13 +124,18 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
     }
 
     public void storagePowerChangeHandler(GridPowerStorageStateChanged ev) {
-        if (ev.storage.isAEPublicPowerStorage()) {
-            switch (ev.type) {
-                case PROVIDE_POWER -> addProvider(ev.storage);
-                case RECEIVE_POWER -> addRequester(ev.storage);
-            }
-        } else {
-            AELog.warn("Attempt to ask the IEnergyGrid to charge a non public energy store.");
+        refreshRegisteredStorage(ev.storage);
+    }
+
+    public void storagePowerChangeHandler(GridPowerStorageChanged ev) {
+        if (!this.energyStorageGroup.contains(ev.storage)) {
+            AELog.warn("Ignoring a power-storage change event for an unregistered storage.");
+            return;
+        }
+
+        switch (ev.type) {
+            case VALUES_CHANGED -> refreshRegisteredStorage(ev.storage);
+            case ROUTING_CHANGED -> invalidateOverlayStorageCache();
         }
     }
 
@@ -210,15 +192,13 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
                 }
             }
 
+            this.energyPowerStatistics.reset();
             double averageLength = 40.0;
             this.avgDrainPerTick *= (averageLength - 1) / averageLength;
             this.avgInjectionPerTick *= (averageLength - 1) / averageLength;
-            this.tickDrainPerTick = 0;
-            this.tickInjectionPerTick = 0;
             this.hasPower = true;
             this.ticksSinceHasPowerChange = 900;
             this.publicPowerState(true, this.grid);
-            this.availableTicksSinceUpdate++;
             return;
         }
 
@@ -246,11 +226,9 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
         this.avgDrainPerTick *= (averageLength - 1) / averageLength;
         this.avgInjectionPerTick *= (averageLength - 1) / averageLength;
 
-        this.avgDrainPerTick += this.tickDrainPerTick / averageLength;
-        this.avgInjectionPerTick += this.tickInjectionPerTick / averageLength;
-
-        this.tickDrainPerTick = 0;
-        this.tickInjectionPerTick = 0;
+        this.avgDrainPerTick += this.energyPowerStatistics.getPowerExtraction() / averageLength;
+        this.avgInjectionPerTick += this.energyPowerStatistics.getPowerInjection() / averageLength;
+        this.energyPowerStatistics.reset();
 
         final boolean currentlyHasPower;
         if (this.drainPerTick > 0.0001) {
@@ -275,11 +253,6 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
             this.publicPowerState(false, this.grid);
         }
 
-        this.availableTicksSinceUpdate++;
-    }
-
-    private static double sanitizePowerAmount(double amount) {
-        return Double.isFinite(amount) && amount > 0 ? amount : 0;
     }
 
     @Override
@@ -304,60 +277,25 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
         this.grid.notifyAllNodes(IGridNodeListener.State.POWER);
     }
 
-    private static double clampPowerResult(double amount, double requested) {
-        if (Double.isNaN(amount) || amount <= 0) {
-            return 0;
-        }
-        if (!Double.isFinite(amount)) {
-            return requested;
-        }
-        return Math.min(amount, requested);
-    }
-
     public Collection<IEnergyOverlayGridConnection> getOverlayGridConnections() {
         return this.overlayGridConnections;
-    }
-
-    private static double clampRemainingPower(double amount, double requested) {
-        if (Double.isNaN(amount)) {
-            return requested;
-        }
-        if (amount <= 0) {
-            return 0;
-        }
-        if (!Double.isFinite(amount)) {
-            return requested;
-        }
-        return Math.min(amount, requested);
-    }
-
-    private static double addPower(double current, double amount) {
-        current = sanitizePowerAmount(current);
-        amount = sanitizePowerAmount(amount);
-        var result = current + amount;
-        return Double.isFinite(result) ? result : Double.MAX_VALUE;
     }
 
     @Override
     public double extractAEPower(double amt, Actionable mode, PowerMultiplier pm) {
         Preconditions.checkArgument(Double.isFinite(amt) && amt >= 0, "amt must be finite and >= 0");
+        Objects.requireNonNull(mode, "mode");
+        Objects.requireNonNull(pm, "pm");
 
-        if (isCreativePowerModeActive()) {
+        var overlay = getOverlayGrid();
+        if (isCreativePowerModeActive(overlay)) {
             return amt;
         }
 
         final double toExtract = pm.multiply(amt);
-        double extracted = 0;
-
-        for (EnergyService service : getConnectedServices()) {
-            extracted = Math.min(toExtract, extracted + service.extractProviderPower(toExtract - extracted, mode));
-
-            if (extracted >= toExtract) {
-                break;
-            }
-        }
-
-        return pm.divide(extracted);
+        Preconditions.checkArgument(Double.isFinite(toExtract) && toExtract >= 0,
+            "multiplied power must be finite and >= 0");
+        return pm.divide(overlay.extractPower(this, toExtract, mode));
     }
 
     @Override
@@ -375,167 +313,23 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
         return this.publicHasPower;
     }
 
-    /**
-     * refresh current stored power.
-     */
-    @VisibleForTesting
-    public void refreshPower() {
-        this.availableTicksSinceUpdate = 0;
-        this.globalAvailablePower = 0;
-        for (IAEPowerStorage p : this.providers) {
-            this.globalAvailablePower = addPower(this.globalAvailablePower, sanitizePowerAmount(p.getAECurrentPower()));
-        }
-    }
-
     @Override
     public double getStoredPower() {
-        if (this.availableTicksSinceUpdate > 90) {
-            this.refreshPower();
-        }
-
-        return Math.max(0.0, this.globalAvailablePower);
-    }
-
-    public double extractProviderPower(double amt, Actionable mode) {
-        Preconditions.checkArgument(Double.isFinite(amt) && amt >= 0, "amt must be finite and >= 0");
-
-        double extractedPower = 0;
-
-        final Iterator<IAEPowerStorage> it = this.providers.iterator();
-
-// when something externally
-        ongoingExtractOperation = true;
-        try {
-            while (extractedPower < amt && it.hasNext()) {
-                final IAEPowerStorage node = it.next();
-
-                final double req = amt - extractedPower;
-                final double newPower = clampPowerResult(node.extractAEPower(req, mode, PowerMultiplier.ONE), req);
-                extractedPower += newPower;
-
-                if (newPower < req && mode == Actionable.MODULATE) {
-                    it.remove();
-                }
-            }
-        } finally {
-// modifies the energy grid.
-            ongoingExtractOperation = false;
-        }
-
-        final double result = Math.min(extractedPower, amt);
-
-        if (mode == Actionable.MODULATE) {
-            if (extractedPower > amt) {
-                this.localStorage.injectAEPower(extractedPower - amt, Actionable.MODULATE);
-            }
-
-            this.globalAvailablePower = Math.max(0.0, this.globalAvailablePower - result);
-            this.tickDrainPerTick = addPower(this.tickDrainPerTick, result);
-        }
-
-        return result;
-    }
-
-    public double injectProviderPower(double amt, Actionable mode) {
-        Preconditions.checkArgument(Double.isFinite(amt) && amt >= 0, "amt must be finite and >= 0");
-
-        final double originalAmount = amt;
-
-        var it = this.requesters.iterator();
-
-// when something externally
-        ongoingInjectOperation = true;
-        try {
-            while (amt > 0 && it.hasNext()) {
-                final IAEPowerStorage node = it.next();
-                amt = clampRemainingPower(node.injectAEPower(amt, mode), amt);
-
-                if (amt > 0 && mode == Actionable.MODULATE) {
-                    it.remove();
-                }
-            }
-        } finally {
-// modifies the energy grid.
-            ongoingInjectOperation = false;
-        }
-
-        final double overflow = Math.max(0.0, amt);
-        final double injected = originalAmount - overflow;
-
-        if (mode == Actionable.MODULATE) {
-            this.globalAvailablePower = addPower(this.globalAvailablePower, injected);
-            this.tickInjectionPerTick = addPower(this.tickInjectionPerTick, injected);
-        }
-
-        return overflow;
-    }
-
-    public double getProviderEnergyDemand(double maxRequired) {
-        Preconditions.checkArgument(Double.isFinite(maxRequired) && maxRequired >= 0,
-            "maxRequired must be finite and >= 0");
-
-        double required = 0;
-
-        final Iterator<IAEPowerStorage> it = this.requesters.iterator();
-        while (required < maxRequired && it.hasNext()) {
-            final IAEPowerStorage node = it.next();
-            if (node.getPowerFlow() != AccessRestriction.READ) {
-                var demand = Math.max(0.0,
-                    sanitizePowerAmount(node.getAEMaxPower()) - sanitizePowerAmount(node.getAECurrentPower()));
-                required = addPower(required, Math.min(demand, maxRequired - required));
-            }
-        }
-
-        return required;
-    }
-
-    private void addRequester(IAEPowerStorage requester) {
-        Preconditions.checkState(!ongoingInjectOperation,
-            "Cannot modify energy requesters while energy is being injected.");
-        if (requester.getPowerFlow().isAllowInsertion()) {
-            this.requesters.add(requester);
-        }
-    }
-
-    private void removeRequester(IAEPowerStorage requester) {
-        Preconditions.checkState(!ongoingInjectOperation,
-            "Cannot modify energy requesters while energy is being injected.");
-        this.requesters.remove(requester);
-    }
-
-    private void addProvider(IAEPowerStorage provider) {
-        Preconditions.checkState(!ongoingExtractOperation,
-            "Cannot modify energy providers while energy is being extracted.");
-        if (provider.getPowerFlow().isAllowExtraction()) {
-            this.providers.add(provider);
-        }
-    }
-
-    private void removeProvider(IAEPowerStorage provider) {
-        Preconditions.checkState(!ongoingExtractOperation,
-            "Cannot modify energy providers while energy is being extracted.");
-        this.providers.remove(provider);
+        var overlay = getOverlayGrid();
+        return isCreativePowerModeActive(overlay) ? CREATIVE_POWER : overlay.getStoredPower(this);
     }
 
     @Override
     public double injectPower(double amt, Actionable mode) {
         Preconditions.checkArgument(Double.isFinite(amt) && amt >= 0, "amt must be finite and >= 0");
+        Objects.requireNonNull(mode, "mode");
 
-        if (isCreativePowerModeActive()) {
+        var overlay = getOverlayGrid();
+        if (isCreativePowerModeActive(overlay)) {
             return amt;
         }
 
-        double leftover = amt;
-
-        for (EnergyService service : getConnectedServices()) {
-            leftover = service.injectProviderPower(leftover, mode);
-
-            if (leftover <= 0) {
-                break;
-            }
-        }
-
-        return leftover;
+        return overlay.injectPower(this, amt, mode);
     }
 
     @Override
@@ -556,18 +350,31 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
     }
 
     public void invalidateOverlayEnergyGrid() {
-        if (this.overlayGrid != null) {
-            this.overlayGrid.invalidate();
+        var currentOverlay = this.overlayGrid;
+        if (currentOverlay != null) {
+            currentOverlay.invalidate();
+        }
+    }
+
+    private void invalidateOverlayStorageCache() {
+        var currentOverlay = this.overlayGrid;
+        if (currentOverlay != null) {
+            currentOverlay.invalidateStorageCache();
         }
     }
 
     public boolean isCreativePowerModeActive() {
-        return AEConfig.instance().isDebugEnergyEnabled() || getOverlayGrid().hasCreativePowerSource();
+        return isCreativePowerModeActive(getOverlayGrid());
+    }
+
+    private boolean isCreativePowerModeActive(EnergyOverlayGrid overlay) {
+        return AEConfig.instance().isDebugEnergyEnabled() || overlay.hasCreativePowerSource();
     }
 
     public void onCreativePowerModeChanged() {
         if (this.overlayGrid != null) {
             this.overlayGrid.setCurrentPassiveGenerator(null);
+            this.overlayGrid.invalidateStorageCache();
         }
 
         if (isCreativePowerModeActive()) {
@@ -584,20 +391,20 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
         return this.creativeEnergyCellCount > 0;
     }
 
-    private EnergyService[] getConnectedServices() {
-        return getOverlayGrid().energyServices;
-    }
-
     private EnergyOverlayGrid getOverlayGrid() {
-        if (this.overlayGrid == null) {
+        var currentOverlay = this.overlayGrid;
+        if (currentOverlay == null || !currentOverlay.isAttachedTo(this)) {
+            this.overlayGrid = null;
             EnergyOverlayGrid.buildCache(this);
+            currentOverlay = this.overlayGrid;
         }
-        return Objects.requireNonNull(this.overlayGrid);
+        return Objects.requireNonNull(currentOverlay);
     }
 
     @Override
     public double getMaxStoredPower() {
-        return addPower(this.providerPowerSum, this.localStorage.getAEMaxPower());
+        var overlay = getOverlayGrid();
+        return isCreativePowerModeActive(overlay) ? CREATIVE_POWER : overlay.getMaximumPower(this);
     }
 
     @Override
@@ -605,26 +412,41 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
         Preconditions.checkArgument(Double.isFinite(maxRequired) && maxRequired >= 0,
             "maxRequired must be finite and >= 0");
 
-        if (isCreativePowerModeActive()) {
+        var overlay = getOverlayGrid();
+        if (isCreativePowerModeActive(overlay)) {
             return 0;
         }
 
-        double required = 0;
-
-        for (EnergyService service : getConnectedServices()) {
-            required += service.getProviderEnergyDemand(maxRequired - required);
-
-            if (required >= maxRequired) {
-                break;
-            }
-        }
-
-        return required;
+        return overlay.getEnergyDemand(this, maxRequired);
     }
 
     @Override
     public void removeNode(IGridNode node) {
+        var currentOverlay = this.overlayGrid;
+        invalidateOverlayStorageCache();
         localStorage.removeNode();
+
+        var passiveGenerator = node.getService(IPassiveEnergyGenerator.class);
+        if (passiveGenerator != null) {
+            passiveGenerators.remove(passiveGenerator);
+            if (currentOverlay != null && currentOverlay.getCurrentPassiveGenerator() == passiveGenerator) {
+                currentOverlay.setCurrentPassiveGenerator(null);
+            }
+        }
+
+        var ps = node.getService(IAEPowerStorage.class);
+        if (ps != null) {
+            this.energyStorageGroup.unregister(ps);
+        }
+
+        if (node.getOwner() instanceof TileCreativeEnergyCell) {
+            Preconditions.checkState(this.creativeEnergyCellCount > 0,
+                "Cannot remove a creative energy cell from an empty service count");
+            this.creativeEnergyCellCount--;
+            if (this.creativeEnergyCellCount == 0 && currentOverlay != null) {
+                currentOverlay.removeCreativePowerService();
+            }
+        }
 
         var gridProvider = node.getService(IEnergyOverlayGridConnection.class);
         if (gridProvider != null) {
@@ -635,35 +457,6 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
         final GridNode gridNode = (GridNode) node;
         this.drainPerTick -= gridNode.getPreviousDraw();
 
-        var passiveGenerator = node.getService(IPassiveEnergyGenerator.class);
-        if (passiveGenerator != null) {
-            passiveGenerators.remove(passiveGenerator);
-
-            var overlayGrid = getOverlayGrid();
-            if (overlayGrid.getCurrentPassiveGenerator() == passiveGenerator) {
-                overlayGrid.setCurrentPassiveGenerator(null);
-            }
-        }
-
-        var ps = node.getService(IAEPowerStorage.class);
-        if (ps != null) {
-            if (ps.isAEPublicPowerStorage()) {
-                if (ps.getPowerFlow() != AccessRestriction.WRITE) {
-                    this.providerPowerSum = Math.max(0.0,
-                        this.providerPowerSum - sanitizePowerAmount(ps.getAEMaxPower()));
-                    this.globalAvailablePower = Math.max(0.0,
-                        this.globalAvailablePower - sanitizePowerAmount(ps.getAECurrentPower()));
-                }
-
-                removeProvider(ps);
-                removeRequester(ps);
-            }
-        }
-
-        if (node.getOwner() instanceof TileCreativeEnergyCell) {
-            this.creativeEnergyCellCount--;
-        }
-
         var watcher = this.watchers.remove(node);
         if (watcher != null) {
             watcher.reset();
@@ -672,7 +465,13 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
 
     @Override
     public void addNode(IGridNode node, @Nullable NBTTagCompound storedData) {
+        invalidateOverlayStorageCache();
         localStorage.addNode();
+
+        var ps = node.getService(IAEPowerStorage.class);
+        if (ps != null) {
+            this.energyStorageGroup.register(ps);
+        }
 
         var gridProvider = node.getService(IEnergyOverlayGridConnection.class);
         if (gridProvider != null) {
@@ -689,23 +488,14 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
             passiveGenerators.add(passiveGenerator);
         }
 
-        var ps = node.getService(IAEPowerStorage.class);
-        if (ps != null) {
-            if (ps.isAEPublicPowerStorage()) {
-                var powerFlow = ps.getPowerFlow();
-                if (powerFlow.isAllowExtraction()) {
-                    this.globalAvailablePower = addPower(this.globalAvailablePower,
-                        sanitizePowerAmount(ps.getAECurrentPower()));
-                    this.providerPowerSum = addPower(this.providerPowerSum, sanitizePowerAmount(ps.getAEMaxPower()));
-                }
-
-                addProvider(ps);
-                addRequester(ps);
-            }
-        }
-
         if (node.getOwner() instanceof TileCreativeEnergyCell) {
+            Preconditions.checkState(this.creativeEnergyCellCount < Integer.MAX_VALUE,
+                "Creative energy cell count overflow");
+            boolean serviceAlreadyCreative = this.creativeEnergyCellCount > 0;
             ++this.creativeEnergyCellCount;
+            if (!serviceAlreadyCreative && this.overlayGrid != null) {
+                this.overlayGrid.addCreativePowerService();
+            }
         }
 
         var ews = node.getService(IEnergyWatcherNode.class);
@@ -721,6 +511,22 @@ public class EnergyService implements IEnergyService, IGridServiceProvider {
                 localStorage.injectAEPower(buffer, Actionable.MODULATE);
             }
         }
+    }
+
+    private void refreshRegisteredStorage(IAEPowerStorage storage) {
+        if (!this.energyStorageGroup.contains(storage)) {
+            AELog.warn("Ignoring a power-storage value event for an unregistered storage.");
+            return;
+        }
+
+        var currentOverlay = this.overlayGrid;
+        if (currentOverlay != null) {
+            currentOverlay.refreshStorageValues(this.energyStorageGroup, storage);
+        }
+    }
+
+    EnergyStorageGroup getEnergyStorageGroup() {
+        return this.energyStorageGroup;
     }
 
 }

--- a/src/main/java/ae2/tile/networking/TileController.java
+++ b/src/main/java/ae2/tile/networking/TileController.java
@@ -23,6 +23,8 @@ import ae2.api.networking.GridFlags;
 import ae2.api.networking.GridHelper;
 import ae2.api.networking.IGridNodeListener;
 import ae2.api.networking.events.GridControllerChange;
+import ae2.api.networking.events.GridPowerStorageChanged;
+import ae2.api.networking.events.GridPowerStorageChanged.ChangeType;
 import ae2.api.networking.events.GridPowerStorageStateChanged;
 import ae2.api.networking.events.GridPowerStorageStateChanged.PowerEventType;
 import ae2.api.networking.pathing.ControllerState;
@@ -154,6 +156,14 @@ public class TileController extends AENetworkedPoweredTile {
     @Override
     protected void emitPowerStateEvent(PowerEventType type) {
         getMainNode().ifPresent(grid -> grid.postEvent(new GridPowerStorageStateChanged(this, type)));
+    }
+
+    @Override
+    protected void emitPowerStorageChanged(ChangeType type) {
+        var grid = getMainNode().getGrid();
+        if (grid != null) {
+            grid.postEvent(new GridPowerStorageChanged(this, type));
+        }
     }
 
     public boolean isOnline() {

--- a/src/main/java/ae2/tile/networking/TileEnergyCell.java
+++ b/src/main/java/ae2/tile/networking/TileEnergyCell.java
@@ -23,6 +23,8 @@ import ae2.api.config.Actionable;
 import ae2.api.config.PowerMultiplier;
 import ae2.api.networking.IGridNode;
 import ae2.api.networking.energy.IAEPowerStorage;
+import ae2.api.networking.events.GridPowerStorageChanged;
+import ae2.api.networking.events.GridPowerStorageChanged.ChangeType;
 import ae2.api.networking.events.GridPowerStorageStateChanged;
 import ae2.api.networking.events.GridPowerStorageStateChanged.PowerEventType;
 import ae2.api.networking.ticking.IGridTickable;
@@ -54,6 +56,7 @@ public class TileEnergyCell extends AENetworkedTile implements IAEPowerStorage, 
     private final StoredEnergyAmount stored;
     private byte currentDisplayLevel;
     private boolean neighborChangePending;
+    private boolean suppressPowerStateEvent;
 
     public TileEnergyCell() {
         super();
@@ -112,7 +115,17 @@ public class TileEnergyCell extends AENetworkedTile implements IAEPowerStorage, 
     public void onReady() {
         super.onReady();
         this.getMainNode().setVisualRepresentation(getItemFromTile());
-        this.stored.setMaximum(this.getConfiguredMaxPower());
+        double previousMaximum = this.stored.getMaximum();
+        boolean previouslySuppressed = this.suppressPowerStateEvent;
+        this.suppressPowerStateEvent = true;
+        try {
+            this.stored.setMaximum(this.getConfiguredMaxPower());
+        } finally {
+            this.suppressPowerStateEvent = previouslySuppressed;
+        }
+        if (Double.compare(previousMaximum, this.stored.getMaximum()) != 0) {
+            emitPowerStorageChanged(ChangeType.ROUTING_CHANGED);
+        }
         IBlockState state = this.world.getBlockState(this.pos);
         if (state.getBlock() instanceof EnergyCellBlock) {
             this.currentDisplayLevel = (byte) state.getValue(EnergyCellBlock.ENERGY_STORAGE).intValue();
@@ -171,6 +184,25 @@ public class TileEnergyCell extends AENetworkedTile implements IAEPowerStorage, 
         }
     }
 
+    private void setStoredEnergy(double maximum, double amount) {
+        double previousMaximum = this.stored.getMaximum();
+        double previousAmount = this.stored.getAmount();
+        boolean previouslySuppressed = this.suppressPowerStateEvent;
+        this.suppressPowerStateEvent = true;
+        try {
+            this.stored.setMaximum(maximum);
+            this.stored.setStored(amount);
+        } finally {
+            this.suppressPowerStateEvent = previouslySuppressed;
+        }
+
+        if (Double.compare(previousMaximum, this.stored.getMaximum()) != 0) {
+            emitPowerStorageChanged(ChangeType.ROUTING_CHANGED);
+        } else if (Double.compare(previousAmount, this.stored.getAmount()) != 0) {
+            emitPowerStorageChanged(ChangeType.VALUES_CHANGED);
+        }
+    }
+
     @Override
     public void saveAdditional(NBTTagCompound data) {
         super.saveAdditional(data);
@@ -183,8 +215,7 @@ public class TileEnergyCell extends AENetworkedTile implements IAEPowerStorage, 
     public void loadTag(NBTTagCompound data) {
         super.loadTag(data);
         double storedEnergy = data.getDouble(INTERNAL_CURRENT_POWER_TAG);
-        this.stored.setMaximum(Math.max(readSavedMaxPower(data, this.stored.getMaximum()), storedEnergy));
-        this.stored.setStored(storedEnergy);
+        setStoredEnergy(Math.max(readSavedMaxPower(data, this.stored.getMaximum()), storedEnergy), storedEnergy);
         this.neighborChangePending = data.getBoolean("neighborChangePending");
     }
 
@@ -194,8 +225,7 @@ public class TileEnergyCell extends AENetworkedTile implements IAEPowerStorage, 
 
         if (mode == SettingsFrom.DISMANTLE_ITEM) {
             double storedEnergy = readStoredEnergy(input);
-            this.stored.setMaximum(Math.max(readMaxPower(input, this.getConfiguredMaxPower()), storedEnergy));
-            this.stored.setStored(storedEnergy);
+            setStoredEnergy(Math.max(readMaxPower(input, this.getConfiguredMaxPower()), storedEnergy), storedEnergy);
         }
     }
 
@@ -265,7 +295,16 @@ public class TileEnergyCell extends AENetworkedTile implements IAEPowerStorage, 
     }
 
     private void emitPowerEvent(PowerEventType type) {
-        getMainNode().ifPresent(grid -> grid.postEvent(new GridPowerStorageStateChanged(this, type)));
+        if (!this.suppressPowerStateEvent) {
+            getMainNode().ifPresent(grid -> grid.postEvent(new GridPowerStorageStateChanged(this, type)));
+        }
+    }
+
+    private void emitPowerStorageChanged(ChangeType type) {
+        var grid = getMainNode().getGrid();
+        if (grid != null) {
+            grid.postEvent(new GridPowerStorageChanged(this, type));
+        }
     }
 
     @Override

--- a/src/main/java/ae2/tile/powersink/AEBasePoweredTile.java
+++ b/src/main/java/ae2/tile/powersink/AEBasePoweredTile.java
@@ -23,6 +23,7 @@ import ae2.api.config.Actionable;
 import ae2.api.config.PowerMultiplier;
 import ae2.api.config.PowerUnit;
 import ae2.api.networking.energy.IAEPowerStorage;
+import ae2.api.networking.events.GridPowerStorageChanged.ChangeType;
 import ae2.api.networking.events.GridPowerStorageStateChanged.PowerEventType;
 import ae2.integration.Integrations;
 import ae2.integration.abstraction.IC2PowerSink;
@@ -42,14 +43,15 @@ import java.util.Set;
 public abstract class AEBasePoweredTile extends AEBaseInvTile
     implements IAEPowerStorage, IExternalPowerSink {
 
-    private static final Set<EnumFacing> ALL_SIDES = ImmutableSet.copyOf(EnumSet.allOf(EnumFacing.class));
+    protected static final Set<EnumFacing> ALL_SIDES = ImmutableSet.copyOf(EnumSet.allOf(EnumFacing.class));
     // the current power buffer.
-    private final StoredEnergyAmount stored = new StoredEnergyAmount(0, 10000, this::emitPowerStateEvent);
+    private final StoredEnergyAmount stored = new StoredEnergyAmount(0, 10000, this::handlePowerStateEvent);
     private final IEnergyStorage forgeEnergyAdapter;
     private final IC2PowerSink ic2Sink;
     private boolean internalPublicPowerStorage = false;
     private AccessRestriction internalPowerFlow = AccessRestriction.READ_WRITE;
     private Set<EnumFacing> internalPowerSides = ALL_SIDES;
+    private boolean suppressPowerStateEvent;
 
     public AEBasePoweredTile() {
         this.forgeEnergyAdapter = new ForgeEnergyAdapter(this);
@@ -94,7 +96,12 @@ public abstract class AEBasePoweredTile extends AEBaseInvTile
     }
 
     protected double funnelPowerIntoStorage(double power, Actionable mode) {
-        return this.injectAEPower(power, mode);
+        double previousPower = this.stored.getAmount();
+        double overflow = this.injectAEPower(power, mode);
+        if (mode == Actionable.MODULATE && Double.compare(previousPower, this.stored.getAmount()) != 0) {
+            emitPowerStorageChanged(ChangeType.VALUES_CHANGED);
+        }
+        return overflow;
     }
 
     @Override
@@ -103,6 +110,15 @@ public abstract class AEBasePoweredTile extends AEBaseInvTile
     }
 
     protected void emitPowerStateEvent(PowerEventType x) {
+    }
+
+    protected void emitPowerStorageChanged(ChangeType type) {
+    }
+
+    private void handlePowerStateEvent(PowerEventType type) {
+        if (!this.suppressPowerStateEvent) {
+            emitPowerStateEvent(type);
+        }
     }
 
     @Override
@@ -157,7 +173,17 @@ public abstract class AEBasePoweredTile extends AEBaseInvTile
     }
 
     public void setInternalCurrentPower(double internalCurrentPower) {
-        this.stored.setStored(internalCurrentPower);
+        double previousPower = this.stored.getAmount();
+        boolean previouslySuppressed = this.suppressPowerStateEvent;
+        this.suppressPowerStateEvent = true;
+        try {
+            this.stored.setStored(internalCurrentPower);
+        } finally {
+            this.suppressPowerStateEvent = previouslySuppressed;
+        }
+        if (Double.compare(previousPower, this.stored.getAmount()) != 0) {
+            emitPowerStorageChanged(ChangeType.VALUES_CHANGED);
+        }
     }
 
     public double getInternalMaxPower() {
@@ -165,7 +191,21 @@ public abstract class AEBasePoweredTile extends AEBaseInvTile
     }
 
     public void setInternalMaxPower(double internalMaxPower) {
-        this.stored.setMaximum(internalMaxPower);
+        double previousMaximum = this.stored.getMaximum();
+        double previousPower = this.stored.getAmount();
+        boolean previouslySuppressed = this.suppressPowerStateEvent;
+        this.suppressPowerStateEvent = true;
+        try {
+            this.stored.setMaximum(internalMaxPower);
+        } finally {
+            this.suppressPowerStateEvent = previouslySuppressed;
+        }
+
+        if (Double.compare(previousMaximum, this.stored.getMaximum()) != 0) {
+            emitPowerStorageChanged(ChangeType.ROUTING_CHANGED);
+        } else if (Double.compare(previousPower, this.stored.getAmount()) != 0) {
+            emitPowerStorageChanged(ChangeType.VALUES_CHANGED);
+        }
     }
 
     private boolean isInternalPublicPowerStorage() {
@@ -173,7 +213,11 @@ public abstract class AEBasePoweredTile extends AEBaseInvTile
     }
 
     public void setInternalPublicPowerStorage(boolean internalPublicPowerStorage) {
+        if (this.internalPublicPowerStorage == internalPublicPowerStorage) {
+            return;
+        }
         this.internalPublicPowerStorage = internalPublicPowerStorage;
+        emitPowerStorageChanged(ChangeType.ROUTING_CHANGED);
     }
 
     private AccessRestriction getInternalPowerFlow() {
@@ -181,7 +225,11 @@ public abstract class AEBasePoweredTile extends AEBaseInvTile
     }
 
     public void setInternalPowerFlow(AccessRestriction internalPowerFlow) {
+        if (this.internalPowerFlow == internalPowerFlow) {
+            return;
+        }
         this.internalPowerFlow = internalPowerFlow;
+        emitPowerStorageChanged(ChangeType.ROUTING_CHANGED);
     }
 
 

--- a/src/main/java/ae2/tile/storage/TileMEChest.java
+++ b/src/main/java/ae2/tile/storage/TileMEChest.java
@@ -32,7 +32,8 @@ import ae2.api.inventories.InternalInventory;
 import ae2.api.networking.GridFlags;
 import ae2.api.networking.IGridNodeListener;
 import ae2.api.networking.IManagedGridNode;
-import ae2.api.networking.events.GridPowerStorageStateChanged;
+import ae2.api.networking.events.GridPowerStorageChanged;
+import ae2.api.networking.events.GridPowerStorageChanged.ChangeType;
 import ae2.api.networking.events.GridPowerStorageStateChanged.PowerEventType;
 import ae2.api.networking.security.IActionSource;
 import ae2.api.orientation.RelativeSide;
@@ -156,10 +157,14 @@ public class TileMEChest extends AENetworkedPoweredTile
 
     @Override
     protected void emitPowerStateEvent(PowerEventType x) {
-        if (x == PowerEventType.RECEIVE_POWER) {
-            ifGridPresent(grid -> grid.postEvent(new GridPowerStorageStateChanged(this, x)));
-        } else {
-            recalculateDisplay();
+        recalculateDisplay();
+    }
+
+    @Override
+    protected void emitPowerStorageChanged(ChangeType type) {
+        var grid = getMainNode().getGrid();
+        if (grid != null) {
+            grid.postEvent(new GridPowerStorageChanged(this, type));
         }
     }
 
@@ -327,7 +332,11 @@ public class TileMEChest extends AENetworkedPoweredTile
                 return stash;
             }
         }
-        return super.extractAEPower(amt - stash, mode) + stash;
+        double extractedFromLocalStorage = super.extractAEPower(amt - stash, mode);
+        if (mode == Actionable.MODULATE && extractedFromLocalStorage > 0) {
+            emitPowerStorageChanged(ChangeType.VALUES_CHANGED);
+        }
+        return extractedFromLocalStorage + stash;
     }
 
     @Override
@@ -408,7 +417,7 @@ public class TileMEChest extends AENetworkedPoweredTile
         inputInventory.readFromNBT(data, "inputInventory");
         cellInventory.readFromNBT(data, "cellInventory");
         viewCellInventory.readFromNBT(data, "viewCellInventory");
-        priority = data.getInteger("priority");
+        updatePriority(data.getInteger("priority"));
         if (data.hasKey("paintedColor", Constants.NBT.TAG_ANY_NUMERIC)) {
             int colorOrdinal = data.getByte("paintedColor") & 0xFF;
             this.paintedColor = readColor(colorOrdinal);
@@ -538,11 +547,21 @@ public class TileMEChest extends AENetworkedPoweredTile
 
     @Override
     public void setPriority(int newValue) {
+        if (updatePriority(newValue)) {
+            saveChanges();
+        }
+    }
+
+    private boolean updatePriority(int newValue) {
+        if (this.priority == newValue) {
+            return false;
+        }
         this.priority = newValue;
         this.cellHandler = null;
         this.isCached = false;
         IStorageProvider.requestUpdate(getMainNode());
-        saveChanges();
+        emitPowerStorageChanged(ChangeType.ROUTING_CHANGED);
+        return true;
     }
 
     private void blinkCell() {


### PR DESCRIPTION
The previous EnergyService essentially traversed the entire network every time to determine whether a specified amount of energy could be extracted or inserted. This commit aims to optimize that part.

The EnergyService now initializes a shared cache on the first read attempt. EnergyNetworks linked together will share this cache. The cache will contain:

- A `List` storing the ME-network-energy-providing parts of all energy component classes, to reduce traversal of the network hierarchy.
- The current energy amount, which is updated synchronously during energy insertion/extraction.
- The current maximum energy amount, alongside the current energy. These two together are used to quickly determine whether energy can be extracted/inserted, instead of traversing the entire table for confirmation.