### PR TITLE
add event-driven incremental storage updates

### DIFF
--- a/API.md
+++ b/API.md
@@ -268,8 +268,14 @@ Storage in grids is organized as mounted `MEStorage` inventories. The storage se
 inventory through `getInventory()`, provides a cached inventory snapshot through `getCachedInventory()`, and manages
 `IStorageProvider` mounts from nodes and global providers.
 
-`getCachedInventory()` is updated at most once per tick and should be preferred when slightly outdated content is
-acceptable. This avoids repeatedly walking the full network inventory.
+`getInventory()` returns a network inventory whose runtime implementation also implements `MEStorageMonitor`.
+Consumers that need live content changes can register an `MEStorageChangeListener`, enumerate the inventory once, and
+then apply the synchronous signed deltas they receive. `onListUpdate()` means the list structure changed and the
+consumer should enumerate once again; it must not be used instead of an exact delta for an ordinary content change.
+
+`getCachedInventory()` uses the same mechanism internally. Event-driven mounts update it synchronously, while legacy
+mounts and invalidated lists are reflected by the next cache rebuild. It should be preferred when slightly outdated
+legacy content is acceptable because it avoids repeatedly walking the full network inventory.
 
 Node-backed storage should implement `IStorageProvider` as a node service. When the node joins or leaves a grid, the
 storage service will mount or unmount it automatically by calling `mountInventories(...)`. Global storage providers
@@ -279,6 +285,12 @@ than by an individual node.
 When a storage provider needs to remove, add, or rebuild its mounts due to an external event or config change, call
 `IStorageProvider.requestUpdate(managedNode)` for node providers, or `refreshGlobalStorageProvider(...)` for global
 providers.
+
+External item or fluid handlers may additionally implement `ExternalStorageMonitor`. A storage bus then enumerates
+that handler once while it is mounted and consumes exact signed deltas instead of polling it. The handler receives the
+active `StorageFilter` when a listener is registered and must synchronously report every later content change on the
+registering server thread. Structural changes that cannot be expressed as deltas use `onListUpdate()` and trigger one
+new enumeration. Handlers that do not implement this interface keep the legacy periodic scan behavior.
 
 #### Auto-Crafting
 

--- a/src/main/java/ae2/api/behaviors/ExternalStorageMonitor.java
+++ b/src/main/java/ae2/api/behaviors/ExternalStorageMonitor.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 TeamAppliedEnergistics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package ae2.api.behaviors;
+
+import ae2.api.config.StorageFilter;
+import ae2.api.storage.MEStorageChangeListener;
+
+/**
+ * Optional event source for an external item or fluid handler exposed to an AE2 storage bus.
+ * <p>
+ * The object implementing the platform storage capability should implement this interface as well. AE2 can then scan
+ * it once for initialization and consume exact change callbacks instead of periodically enumerating all slots or tanks.
+ */
+public interface ExternalStorageMonitor {
+
+    /**
+     * Registers a listener for one storage-filter view.
+     * <p>
+     * Changes must use the signed-delta contract of
+     * {@link MEStorageChangeListener#onStackChange(ae2.api.stacks.AEKey, long)} and must be delivered synchronously on
+     * the registering server thread. A listener instance may only be registered once with this monitor, but the
+     * monitor must support multiple distinct listeners observing the same capability view.
+     *
+     * @param storageFilter     whether the view includes all resources or only extractable resources
+     * @param listener          listener that receives exact content changes
+     * @param verificationToken opaque registration token used to reject stale callbacks
+     * @throws IllegalStateException if the listener is already registered
+     */
+    void addListener(StorageFilter storageFilter, MEStorageChangeListener listener, Object verificationToken);
+
+    /**
+     * Removes a previously registered listener. Calling this for an absent listener has no effect. No callback may be
+     * made to the listener after this method returns.
+     *
+     * @param listener listener to remove
+     */
+    void removeListener(MEStorageChangeListener listener);
+
+}

--- a/src/main/java/ae2/api/networking/storage/IStorageService.java
+++ b/src/main/java/ae2/api/networking/storage/IStorageService.java
@@ -41,8 +41,8 @@ public interface IStorageService extends IGridService {
     MEStorage getInventory();
 
     /**
-     * Returns the cached content of the network inventory. The cache is <strong>updated at most once per tick</strong>.
-     * Changes to network inventory will not be reflected by the cache until the next tick.
+     * Returns the cached content of the network inventory. Event-driven storage updates this cache synchronously.
+     * Changes from legacy storage or invalidated storage lists are reflected when the cache is next rebuilt.
      * <p/>
      * Should be used when slightly outdated content is not a big deal. Preferred to
      * {@code getInventory().getAvailableStacks()} for performance reasons.

--- a/src/main/java/ae2/api/storage/MEStorageChangeListener.java
+++ b/src/main/java/ae2/api/storage/MEStorageChangeListener.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 TeamAppliedEnergistics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package ae2.api.storage;
+
+import ae2.api.stacks.AEKey;
+
+/**
+ * Receives authoritative content changes from an {@link MEStorageMonitor}.
+ * <p>
+ * The listener is intended for storage aggregation without repeatedly enumerating the monitored storage. Callbacks
+ * are synchronous and must run on the same server thread that registered the listener.
+ */
+public interface MEStorageChangeListener {
+
+    /**
+     * Verifies that this listener still belongs to the registration represented by {@code verificationToken}.
+     * Monitors must call this before dispatching a change and must remove registrations that are no longer valid.
+     *
+     * @param verificationToken opaque token supplied when the listener was registered
+     * @return {@code true} while callbacks for this registration are still accepted
+     */
+    boolean isValid(Object verificationToken);
+
+    /**
+     * Reports a signed change to one resource in the monitored storage view.
+     * <p>
+     * Positive values add resources and negative values remove resources. Zero has no effect. Implementations must
+     * report every content change exactly once and must not replace ordinary changes with {@link #onListUpdate()}.
+     *
+     * @param what  resource whose amount changed
+     * @param delta signed amount added to or removed from the monitored storage
+     */
+    void onStackChange(AEKey what, long delta);
+
+    /**
+     * Reports that a structural change cannot be represented by exact deltas. The listener remains registered and
+     * will enumerate the monitor once again when its cache is next required. This must not be used for ordinary
+     * content changes.
+     */
+    void onListUpdate();
+}

--- a/src/main/java/ae2/api/storage/MEStorageMonitor.java
+++ b/src/main/java/ae2/api/storage/MEStorageMonitor.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 TeamAppliedEnergistics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package ae2.api.storage;
+
+/**
+ * An {@link MEStorage} that can publish exact content changes after its initial enumeration.
+ * <p>
+ * Consumers register before enumerating the storage once. Implementations must synchronously publish every later
+ * content change as a signed delta, allowing consumers to update their aggregate cache without rescanning this
+ * storage. If a structural change cannot be represented by exact deltas, the monitor must request one new enumeration
+ * through {@link MEStorageChangeListener#onListUpdate()}.
+ */
+public interface MEStorageMonitor extends MEStorage {
+
+    /**
+     * Registers a listener for this storage view.
+     * <p>
+     * The monitor must retain the token and call {@link MEStorageChangeListener#isValid(Object)} before every callback.
+     * A listener instance may only be registered once with a monitor.
+     *
+     * @param listener           listener that receives synchronous signed changes
+     * @param verificationToken opaque registration token used to reject stale callbacks
+     * @throws IllegalStateException if the listener is already registered
+     */
+    void addListener(MEStorageChangeListener listener, Object verificationToken);
+
+    /**
+     * Removes a previously registered listener. Calling this for an absent listener has no effect. No callback may be
+     * made to the listener after this method returns.
+     *
+     * @param listener listener to remove
+     */
+    void removeListener(MEStorageChangeListener listener);
+}

--- a/src/main/java/ae2/me/service/StorageService.java
+++ b/src/main/java/ae2/me/service/StorageService.java
@@ -23,11 +23,13 @@ import ae2.api.networking.IGridServiceProvider;
 import ae2.api.networking.storage.IStorageService;
 import ae2.api.networking.storage.IStorageWatcherNode;
 import ae2.api.stacks.AEKey;
-import ae2.api.stacks.AEKey2LongMap;
 import ae2.api.stacks.KeyCounter;
 import ae2.api.storage.IStorageMounts;
 import ae2.api.storage.IStorageProvider;
 import ae2.api.storage.MEStorage;
+import ae2.api.storage.MEStorageChangeListener;
+import ae2.api.storage.MEStorageMonitor;
+import ae2.core.AELog;
 import ae2.me.helpers.InterestManager;
 import ae2.me.helpers.StackWatcher;
 import ae2.me.storage.NetworkStorage;
@@ -51,20 +53,24 @@ public class StorageService implements IStorageService, IGridServiceProvider {
     private final ObjectList<ProviderState> globalProviders = new ObjectArrayList<>();
     private final SetMultimap<AEKey, StackWatcher<IStorageWatcherNode>> interests = HashMultimap.create();
     private final InterestManager<StackWatcher<IStorageWatcherNode>> interestManager = new InterestManager<>(this.interests);
-    private final NetworkStorage storage = new NetworkStorage();
-    private final KeyCounter cachedAvailableStacks = KeyCounter.saturating();
-    private final AEKey2LongMap cachedAvailableAmounts = new AEKey2LongMap.OpenHashMap();
+    private final NetworkStorage storage = new NetworkStorage(this::getCachedInventory, this::invalidateCache);
+    private KeyCounter cachedAvailableStacks = KeyCounter.saturating();
+    private KeyCounter cachedAvailableScratch = KeyCounter.saturating();
     private final Reference2ObjectMap<IGridNode, StackWatcher<IStorageWatcherNode>> watchers =
         new Reference2ObjectOpenHashMap<>();
 
     private boolean cachedStacksNeedUpdate = true;
+    private boolean cacheInitialized;
+    private boolean processingMonitorCallback;
+    private int legacyMountCount;
 
     @Override
     public void onServerEndTick() {
-        if (this.interestManager.isEmpty()) {
-            this.cachedStacksNeedUpdate = true;
-        } else {
+        boolean cacheIsObserved = !this.interestManager.isEmpty() || this.storage.hasListeners();
+        if (cacheIsObserved && (this.cachedStacksNeedUpdate || this.legacyMountCount > 0)) {
             updateCachedStacks();
+        } else if (!cacheIsObserved && this.legacyMountCount > 0) {
+            this.cachedStacksNeedUpdate = true;
         }
     }
 
@@ -73,35 +79,77 @@ public class StorageService implements IStorageService, IGridServiceProvider {
     }
 
     private void updateCachedStacks() {
+        var previous = this.cachedAvailableStacks;
+        var replacement = this.cachedAvailableScratch;
+
+        replacement.reset();
+        this.storage.getAvailableStacksRaw(replacement);
+        replacement.removeZeros();
+        this.cachedAvailableStacks = replacement;
+        this.cachedAvailableScratch = previous;
         this.cachedStacksNeedUpdate = false;
 
-        this.cachedAvailableStacks.clear();
-        this.storage.getAvailableStacks(this.cachedAvailableStacks);
-        this.cachedAvailableStacks.removeEmptySubmaps();
-
-        for (var entry : this.cachedAvailableStacks) {
-            var what = entry.getKey();
-            var newAmount = sanitizeAmount(entry.getLongValue());
-            if (newAmount != this.cachedAvailableAmounts.getLong(what)) {
-                postWatcherUpdate(what, newAmount);
-            }
-        }
-
-        if (!this.cachedAvailableAmounts.isEmpty()) {
-            for (var what : this.cachedAvailableAmounts.keySet()) {
-                if (this.cachedAvailableStacks.get(what) == 0) {
-                    postWatcherUpdate(what, 0);
+        if (!this.cacheInitialized) {
+            this.cacheInitialized = true;
+            for (var entry : replacement) {
+                var amount = sanitizeAmount(entry.getLongValue());
+                if (amount > 0) {
+                    postWatcherUpdate(entry.getKey(), amount);
                 }
             }
+            return;
         }
 
-        this.cachedAvailableAmounts.clear();
-        for (var entry : this.cachedAvailableStacks) {
-            var amount = sanitizeAmount(entry.getLongValue());
-            if (amount > 0) {
-                this.cachedAvailableAmounts.put(entry.getKey(), amount);
+        for (var entry : replacement) {
+            var what = entry.getKey();
+            var newAmount = sanitizeAmount(entry.getLongValue());
+            var oldAmount = sanitizeAmount(previous.get(what));
+            if (newAmount != oldAmount) {
+                postWatcherUpdate(what, newAmount);
+                this.storage.postChange(what, newAmount - oldAmount);
             }
         }
+
+        for (var entry : previous) {
+            var what = entry.getKey();
+            var oldAmount = sanitizeAmount(entry.getLongValue());
+            if (oldAmount > 0 && replacement.get(what) == 0) {
+                postWatcherUpdate(what, 0);
+                this.storage.postChange(what, -oldAmount);
+            }
+        }
+    }
+
+    private void applyMonitorDelta(AEKey what, long delta, Object source) {
+        if (what == null) {
+            AELog.error("Storage monitor %s reported a null key; scheduling a full storage scan.", source);
+            invalidateCache();
+            return;
+        }
+        if (delta == 0) {
+            return;
+        }
+        if (this.cachedStacksNeedUpdate || !this.cacheInitialized) {
+            return;
+        }
+
+        long current = sanitizeAmount(this.cachedAvailableStacks.get(what));
+        if ((current == Long.MAX_VALUE && delta < 0)
+            || (delta < 0 && (delta == Long.MIN_VALUE || current < -delta))) {
+            AELog.error("Storage monitor %s reported delta %d for %s with cached amount %d; scheduling a full storage scan.",
+                source, delta, what, current);
+            invalidateCache();
+            return;
+        }
+
+        long updated = delta > 0 && current > Long.MAX_VALUE - delta ? Long.MAX_VALUE : current + delta;
+        if (updated == 0) {
+            this.cachedAvailableStacks.remove(what);
+        } else {
+            this.cachedAvailableStacks.set(what, updated);
+        }
+        postWatcherUpdate(what, updated);
+        this.storage.postChange(what, delta);
     }
 
     private void postWatcherUpdate(AEKey what, long newAmount) {
@@ -158,7 +206,8 @@ public class StorageService implements IStorageService, IGridServiceProvider {
 
     @Override
     public void addGlobalStorageProvider(IStorageProvider provider) {
-        for (var state : this.globalProviders) {
+        for (int i = 0; i < this.globalProviders.size(); i++) {
+            var state = this.globalProviders.get(i);
             if (state.provider == provider) {
                 throw new IllegalArgumentException("Duplicate storage provider registration for " + provider);
             }
@@ -171,12 +220,12 @@ public class StorageService implements IStorageService, IGridServiceProvider {
 
     @Override
     public void removeGlobalStorageProvider(IStorageProvider provider) {
-        var iterator = this.globalProviders.iterator();
-        while (iterator.hasNext()) {
-            var state = iterator.next();
+        for (int i = this.globalProviders.size() - 1; i >= 0; i--) {
+            var state = this.globalProviders.get(i);
             if (state.provider == provider) {
-                iterator.remove();
+                this.globalProviders.remove(i);
                 state.unmount();
+                return;
             }
         }
     }
@@ -192,7 +241,8 @@ public class StorageService implements IStorageService, IGridServiceProvider {
 
     @Override
     public void refreshGlobalStorageProvider(IStorageProvider provider) {
-        for (var state : this.globalProviders) {
+        for (int i = 0; i < this.globalProviders.size(); i++) {
+            var state = this.globalProviders.get(i);
             if (state.provider == provider) {
                 state.update();
                 return;
@@ -204,7 +254,10 @@ public class StorageService implements IStorageService, IGridServiceProvider {
 
     @Override
     public void invalidateCache() {
-        this.cachedStacksNeedUpdate = true;
+        if (!this.cachedStacksNeedUpdate) {
+            this.cachedStacksNeedUpdate = true;
+            this.storage.postListUpdate();
+        }
     }
 
     @Override
@@ -225,6 +278,8 @@ public class StorageService implements IStorageService, IGridServiceProvider {
     private class ProviderState implements IStorageMounts {
         private final IStorageProvider provider;
         private final ReferenceSet<MEStorage> inventories = new ReferenceOpenHashSet<>();
+        private final Reference2ObjectMap<MEStorage, SourceListener> monitorListeners =
+            new Reference2ObjectOpenHashMap<>();
         private boolean mounted;
 
         ProviderState(IStorageProvider provider) {
@@ -248,6 +303,13 @@ public class StorageService implements IStorageService, IGridServiceProvider {
             }
 
             storage.mount(priority, inventory);
+            if (inventory instanceof MEStorageMonitor monitor) {
+                var listener = new SourceListener(this, monitor, Thread.currentThread());
+                this.monitorListeners.put(inventory, listener);
+                monitor.addListener(listener, inventory);
+            } else {
+                legacyMountCount++;
+            }
             invalidateCache();
         }
 
@@ -263,10 +325,76 @@ public class StorageService implements IStorageService, IGridServiceProvider {
 
             this.mounted = false;
             for (var inventory : this.inventories) {
+                var listener = this.monitorListeners.remove(inventory);
+                if (listener != null) {
+                    listener.monitor.removeListener(listener);
+                } else {
+                    legacyMountCount--;
+                }
                 storage.unmount(inventory);
             }
             this.inventories.clear();
             invalidateCache();
+        }
+    }
+
+    private final class SourceListener implements MEStorageChangeListener {
+        private final ProviderState provider;
+        private final MEStorageMonitor monitor;
+        private final Thread ownerThread;
+
+        private SourceListener(ProviderState provider, MEStorageMonitor monitor, Thread ownerThread) {
+            this.provider = provider;
+            this.monitor = monitor;
+            this.ownerThread = ownerThread;
+        }
+
+        @Override
+        public boolean isValid(Object verificationToken) {
+            return verificationToken == this.monitor
+                && this.provider.mounted
+                && this.provider.monitorListeners.get(this.monitor) == this;
+        }
+
+        @Override
+        public void onStackChange(AEKey what, long delta) {
+            if (Thread.currentThread() != this.ownerThread) {
+                AELog.error("Storage monitor %s invoked a callback from the wrong thread; scheduling a full storage scan.",
+                    this.monitor);
+                cachedStacksNeedUpdate = true;
+                return;
+            }
+            if (processingMonitorCallback || storage.isDispatchingListeners()) {
+                AELog.error("Reentrant storage monitor callback from %s; scheduling a full storage scan.", this.monitor);
+                invalidateCache();
+                return;
+            }
+            processingMonitorCallback = true;
+            try {
+                applyMonitorDelta(what, delta, this.monitor);
+            } finally {
+                processingMonitorCallback = false;
+            }
+        }
+
+        @Override
+        public void onListUpdate() {
+            if (Thread.currentThread() != this.ownerThread) {
+                AELog.error("Storage monitor %s invalidated its list from the wrong thread.", this.monitor);
+                cachedStacksNeedUpdate = true;
+                return;
+            }
+            if (processingMonitorCallback || storage.isDispatchingListeners()) {
+                AELog.error("Reentrant storage list update from %s; scheduling a full storage scan.", this.monitor);
+                invalidateCache();
+                return;
+            }
+            processingMonitorCallback = true;
+            try {
+                invalidateCache();
+            } finally {
+                processingMonitorCallback = false;
+            }
         }
     }
 }

--- a/src/main/java/ae2/me/storage/CompositeStorage.java
+++ b/src/main/java/ae2/me/storage/CompositeStorage.java
@@ -18,15 +18,24 @@
 
 package ae2.me.storage;
 
+import ae2.api.behaviors.ExternalStorageMonitor;
 import ae2.api.config.Actionable;
+import ae2.api.config.StorageFilter;
 import ae2.api.networking.security.IActionSource;
 import ae2.api.networking.ticking.TickRateModulation;
 import ae2.api.stacks.AEKey;
 import ae2.api.stacks.AEKeyType;
 import ae2.api.stacks.KeyCounter;
 import ae2.api.storage.MEStorage;
+import ae2.api.storage.MEStorageChangeListener;
+import ae2.api.storage.MEStorageMonitor;
+import ae2.core.AELog;
 import ae2.core.localization.GuiText;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectList;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 
@@ -34,18 +43,37 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Combines several ME storages that each handle only a given key-space.
+ * Combines several external storages that each handle a given key-space. External monitors are only subscribed while
+ * this storage itself has listeners; standalone users retain the original polling behavior.
  */
-public class CompositeStorage implements MEStorage, ITickingMonitor {
-    private final InventoryCache cache;
+public class CompositeStorage implements MEStorageMonitor, ITickingMonitor {
+    private final ObjectList<ListenerRegistration> listeners = new ObjectArrayList<>();
+    private final ObjectList<ListenerRegistration> listenerDispatchBuffer = new ObjectArrayList<>();
+    private final Reference2ObjectMap<MEStorage, SourceGroup> sourceGroupsByStorage =
+        new Reference2ObjectOpenHashMap<>();
+    private final Reference2ObjectMap<ExternalStorageMonitor, SourceGroup> sourceGroups =
+        new Reference2ObjectOpenHashMap<>();
 
     private Map<AEKeyType, MEStorage> storages;
-
-    private boolean forceCacheRebuild = true;
+    private KeyCounter cache = KeyCounter.saturating();
+    private KeyCounter cacheScratch = KeyCounter.saturating();
+    private KeyCounter eventCache = KeyCounter.saturating();
+    private KeyCounter eventScratch = KeyCounter.saturating();
+    private KeyCounter legacyCache = KeyCounter.saturating();
+    private KeyCounter legacyScratch = KeyCounter.saturating();
+    private boolean cacheInitialized;
+    private boolean standaloneDirty = true;
+    private boolean eventDirty = true;
+    private boolean legacyDirty = true;
+    private boolean hasLegacyStorage;
+    private boolean sourcesBound;
+    private boolean processingSourceCallback;
+    private boolean dispatchingListeners;
+    private boolean dispatchingListUpdate;
+    private boolean listUpdatePending;
 
     public CompositeStorage(Map<AEKeyType, MEStorage> storages) {
-        this.storages = storages;
-        this.cache = new InventoryCache();
+        this.storages = Objects.requireNonNull(storages);
     }
 
     @SuppressWarnings("unused")
@@ -54,43 +82,46 @@ public class CompositeStorage implements MEStorage, ITickingMonitor {
     }
 
     public void setStorages(Map<AEKeyType, MEStorage> storages) {
+        if (this.sourcesBound) {
+            unbindSources();
+        }
         this.storages = Objects.requireNonNull(storages);
-        this.forceCacheRebuild = true;
+        if (!this.listeners.isEmpty()) {
+            bindSources();
+        }
+        invalidateLocalCaches();
+        requestListUpdate();
     }
 
     @Override
     public boolean isPreferredStorageFor(AEKey what, IActionSource source) {
-        var storage = storages.get(what.getType());
+        var storage = this.storages.get(what.getType());
         return storage != null && storage.isPreferredStorageFor(what, source);
     }
 
     @Override
     public boolean isStickyStorageFor(AEKey what, IActionSource source) {
-        var storage = storages.get(what.getType());
+        var storage = this.storages.get(what.getType());
         return storage != null && storage.isStickyStorageFor(what, source);
     }
 
     @Override
     public long insert(AEKey what, long amount, Actionable mode, IActionSource source) {
-        var storage = storages.get(what.getType());
+        var storage = this.storages.get(what.getType());
         var inserted = storage != null ? storage.insert(what, amount, mode, source) : 0;
-
-        if (inserted > 0 && mode == Actionable.MODULATE) {
-            forceCacheRebuild = true;
+        if (inserted > 0 && mode == Actionable.MODULATE && !isEventDriven(storage)) {
+            markLegacyDirty();
         }
-
         return inserted;
     }
 
     @Override
     public long extract(AEKey what, long amount, Actionable mode, IActionSource source) {
-        var storage = storages.get(what.getType());
+        var storage = this.storages.get(what.getType());
         var extracted = storage != null ? storage.extract(what, amount, mode, source) : 0;
-
-        if (extracted > 0 && mode == Actionable.MODULATE) {
-            forceCacheRebuild = true;
+        if (extracted > 0 && mode == Actionable.MODULATE && !isEventDriven(storage)) {
+            markLegacyDirty();
         }
-
         return extracted;
     }
 
@@ -98,7 +129,7 @@ public class CompositeStorage implements MEStorage, ITickingMonitor {
     public ITextComponent getDescription() {
         ITextComponent types = new TextComponentString("");
         boolean first = true;
-        for (var keyType : storages.keySet()) {
+        for (var keyType : this.storages.keySet()) {
             if (!first) {
                 types.appendText(", ");
             } else {
@@ -111,64 +142,461 @@ public class CompositeStorage implements MEStorage, ITickingMonitor {
 
     @Override
     public TickRateModulation onTick() {
-        forceCacheRebuild = false;
-        boolean changed = this.cache.update();
-        if (changed) {
-            return TickRateModulation.URGENT;
-        } else {
+        if (this.listeners.isEmpty()) {
+            if (this.storages.isEmpty()) {
+                return TickRateModulation.SLEEP;
+            }
+            return refreshStandalone() ? TickRateModulation.URGENT : TickRateModulation.SLOWER;
+        }
+
+        if (!this.hasLegacyStorage) {
+            return TickRateModulation.SLEEP;
+        }
+        if (!this.cacheInitialized) {
             return TickRateModulation.SLOWER;
         }
+
+        boolean changed = refreshLegacyStorages(!this.legacyDirty);
+        return changed ? TickRateModulation.URGENT : TickRateModulation.SLOWER;
     }
 
     @Override
     public void getAvailableStacks(KeyCounter out) {
-        if (forceCacheRebuild) {
-            forceCacheRebuild = false;
-            cache.update();
+        if (this.listeners.isEmpty()) {
+            if (!this.cacheInitialized || this.standaloneDirty) {
+                refreshStandalone();
+            }
+        } else {
+            ensureMonitoredCache();
         }
-        this.cache.getAvailableKeys(out);
+        out.addAll(this.cache);
     }
 
-    private class InventoryCache {
-        private KeyCounter frontBuffer = KeyCounter.saturating();
-        private KeyCounter backBuffer = KeyCounter.saturating();
-
-        public boolean update() {
-// Flip back & front buffer and start building a new list
-            var tmp = backBuffer;
-            backBuffer = frontBuffer;
-            frontBuffer = tmp;
-            frontBuffer.reset();
-
-// Rebuild the front buffer
-            for (var storage : storages.values()) {
-                storage.getAvailableStacks(frontBuffer);
+    @Override
+    public void addListener(MEStorageChangeListener listener, Object verificationToken) {
+        for (int i = 0; i < this.listeners.size(); i++) {
+            if (this.listeners.get(i).listener == listener) {
+                throw new IllegalStateException("The storage listener is already registered.");
             }
-
-            boolean changed = false;
-            for (var entry : frontBuffer) {
-                var old = backBuffer.get(entry.getKey());
-                if (old == 0 || old != entry.getLongValue()) {
-                    changed = true;
-                    break;
-                }
-            }
-            if (!changed) {
-                for (var oldEntry : backBuffer) {
-                    if (frontBuffer.get(oldEntry.getKey()) == 0) {
-                        changed = true;
-                        break;
-                    }
-                }
-            }
-
-            frontBuffer.removeZeros();
-
-            return changed;
         }
 
-        public void getAvailableKeys(KeyCounter out) {
-            out.addAll(frontBuffer);
+        boolean firstListener = this.listeners.isEmpty();
+        this.listeners.add(new ListenerRegistration(listener, verificationToken));
+        if (firstListener) {
+            bindSources();
+            invalidateLocalCaches();
+        }
+    }
+
+    @Override
+    public void removeListener(MEStorageChangeListener listener) {
+        for (int i = this.listeners.size() - 1; i >= 0; i--) {
+            var registration = this.listeners.get(i);
+            if (registration.listener == listener) {
+                registration.active = false;
+                this.listeners.remove(i);
+            }
+        }
+        if (this.listeners.isEmpty() && this.sourcesBound) {
+            unbindSources();
+            invalidateLocalCaches();
+        }
+    }
+
+    private void bindSources() {
+        if (this.sourcesBound) {
+            throw new IllegalStateException("External storage sources are already bound.");
+        }
+
+        this.hasLegacyStorage = false;
+        for (var storage : this.storages.values()) {
+            if (storage instanceof ExternalStorageFacade facade) {
+                facade.setChangeListener(null);
+                var externalMonitor = facade.getExternalMonitor();
+                if (externalMonitor != null) {
+                    var group = this.sourceGroups.get(externalMonitor);
+                    if (group == null) {
+                        group = new SourceGroup(externalMonitor, facade.getStorageFilter(), Thread.currentThread());
+                        this.sourceGroups.put(externalMonitor, group);
+                    }
+                    group.addFacade(facade);
+                    this.sourceGroupsByStorage.put(storage, group);
+                    continue;
+                }
+            }
+            this.hasLegacyStorage = true;
+        }
+        this.sourcesBound = true;
+        for (var group : this.sourceGroups.values()) {
+            group.monitor.addListener(group.storageFilter, group, group);
+        }
+    }
+
+    private void unbindSources() {
+        for (var group : this.sourceGroups.values()) {
+            group.monitor.removeListener(group);
+        }
+        this.sourceGroups.clear();
+        this.sourceGroupsByStorage.clear();
+        this.sourcesBound = false;
+        this.hasLegacyStorage = false;
+    }
+
+    private boolean isEventDriven(MEStorage storage) {
+        return storage != null && this.sourceGroupsByStorage.containsKey(storage);
+    }
+
+    private void invalidateLocalCaches() {
+        this.cacheInitialized = false;
+        this.standaloneDirty = true;
+        this.eventDirty = true;
+        this.legacyDirty = true;
+    }
+
+    private void ensureMonitoredCache() {
+        if (!this.cacheInitialized) {
+            scanEventStorages();
+            scanLegacyStorages();
+            rebuildTotalCache();
+            this.cacheInitialized = true;
+            this.eventDirty = false;
+            this.legacyDirty = false;
+            return;
+        }
+
+        boolean rebuilt = false;
+        if (this.eventDirty) {
+            scanEventStorages();
+            this.eventDirty = false;
+            rebuilt = true;
+        }
+        if (this.legacyDirty) {
+            scanLegacyStorages();
+            this.legacyDirty = false;
+            rebuilt = true;
+        }
+        if (rebuilt) {
+            rebuildTotalCache();
+        }
+    }
+
+    private boolean refreshStandalone() {
+        this.cacheScratch.reset();
+        for (var storage : this.storages.values()) {
+            storage.getAvailableStacks(this.cacheScratch);
+        }
+        this.cacheScratch.removeZeros();
+        boolean changed = hasDifference(this.cache, this.cacheScratch);
+        var previous = this.cache;
+        this.cache = this.cacheScratch;
+        this.cacheScratch = previous;
+        this.cacheInitialized = true;
+        this.standaloneDirty = false;
+        return changed;
+    }
+
+    private void scanEventStorages() {
+        this.eventScratch.reset();
+        for (var storage : this.storages.values()) {
+            if (isEventDriven(storage)) {
+                storage.getAvailableStacks(this.eventScratch);
+            }
+        }
+        this.eventScratch.removeZeros();
+        var previous = this.eventCache;
+        this.eventCache = this.eventScratch;
+        this.eventScratch = previous;
+    }
+
+    private void scanLegacyStorages() {
+        this.legacyScratch.reset();
+        for (var storage : this.storages.values()) {
+            if (!isEventDriven(storage)) {
+                storage.getAvailableStacks(this.legacyScratch);
+            }
+        }
+        this.legacyScratch.removeZeros();
+        var previous = this.legacyCache;
+        this.legacyCache = this.legacyScratch;
+        this.legacyScratch = previous;
+    }
+
+    private boolean refreshLegacyStorages(boolean publishChanges) {
+        var previous = this.legacyCache;
+        scanLegacyStorages();
+        boolean changed = hasDifference(previous, this.legacyCache);
+        boolean publishedExactly = !publishChanges || publishDifference(previous, this.legacyCache);
+        this.legacyDirty = false;
+        if (!publishChanges || !publishedExactly) {
+            rebuildTotalCache();
+        }
+        if (!publishedExactly) {
+            requestListUpdate();
+        }
+        return changed;
+    }
+
+    private void rebuildTotalCache() {
+        this.cacheScratch.reset();
+        this.cacheScratch.addAll(this.eventCache);
+        this.cacheScratch.addAll(this.legacyCache);
+        this.cacheScratch.removeZeros();
+        var previous = this.cache;
+        this.cache = this.cacheScratch;
+        this.cacheScratch = previous;
+    }
+
+    private boolean hasDifference(KeyCounter previous, KeyCounter replacement) {
+        for (var entry : replacement) {
+            if (entry.getLongValue() != previous.get(entry.getKey())) {
+                return true;
+            }
+        }
+        for (var entry : previous) {
+            if (entry.getLongValue() > 0 && replacement.get(entry.getKey()) == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean publishDifference(KeyCounter previous, KeyCounter replacement) {
+        boolean exact = true;
+        for (var entry : replacement) {
+            long oldAmount = previous.get(entry.getKey());
+            long delta = entry.getLongValue() - oldAmount;
+            if (delta != 0 && !applyKnownDelta(this.cache, entry.getKey(), delta)) {
+                exact = false;
+            }
+        }
+        for (var entry : previous) {
+            if (entry.getLongValue() > 0 && replacement.get(entry.getKey()) == 0
+                && !applyKnownDelta(this.cache, entry.getKey(), -entry.getLongValue())) {
+                exact = false;
+            }
+        }
+        return exact;
+    }
+
+    private void applyEventDelta(AEKey what, long delta, Object source) {
+        if (!this.cacheInitialized || this.eventDirty) {
+            this.eventDirty = true;
+            requestListUpdate();
+            return;
+        }
+        if (!canApplyDelta(this.eventCache, what, delta, source)
+            || !canApplyDelta(this.cache, what, delta, source)) {
+            this.eventDirty = true;
+            requestListUpdate();
+            return;
+        }
+        applyDelta(this.eventCache, what, delta);
+        applyDelta(this.cache, what, delta);
+        notifyDelta(what, delta);
+    }
+
+    private boolean applyKnownDelta(KeyCounter target, AEKey what, long delta) {
+        if (!canApplyDelta(target, what, delta, "Legacy external storage scan")) {
+            return false;
+        }
+        applyDelta(target, what, delta);
+        notifyDelta(what, delta);
+        return true;
+    }
+
+    private boolean canApplyDelta(KeyCounter target, AEKey what, long delta, Object source) {
+        if (what == null || delta == 0) {
+            if (what == null) {
+                AELog.error("%s reported a null storage key.", source);
+            }
+            return what != null;
+        }
+        long current = Math.max(0, target.get(what));
+        if ((current == Long.MAX_VALUE && delta < 0)
+            || (delta < 0 && (delta == Long.MIN_VALUE || current < -delta))) {
+            AELog.error("%s reported delta %d for %s with cached amount %d.", source, delta, what, current);
+            return false;
+        }
+        return true;
+    }
+
+    private void applyDelta(KeyCounter target, AEKey what, long delta) {
+        long current = Math.max(0, target.get(what));
+        long updated = delta > 0 && current > Long.MAX_VALUE - delta ? Long.MAX_VALUE : current + delta;
+        if (updated == 0) {
+            target.remove(what);
+        } else {
+            target.set(what, updated);
+        }
+    }
+
+    private void markLegacyDirty() {
+        if (this.listeners.isEmpty()) {
+            this.standaloneDirty = true;
+        } else if (!this.legacyDirty) {
+            this.legacyDirty = true;
+            requestListUpdate();
+        }
+    }
+
+    private void notifyDelta(AEKey what, long delta) {
+        dispatchListeners(what, delta, false);
+    }
+
+    private void notifyListUpdate() {
+        dispatchListeners(null, 0, true);
+    }
+
+    private void requestListUpdate() {
+        if (this.listeners.isEmpty()) {
+            return;
+        }
+        if (this.dispatchingListeners || this.processingSourceCallback) {
+            if (!this.dispatchingListUpdate) {
+                this.listUpdatePending = true;
+            }
+        } else {
+            notifyListUpdate();
+        }
+    }
+
+    private void dispatchListeners(AEKey what, long delta, boolean listUpdate) {
+        if (this.dispatchingListeners) {
+            AELog.error("Reentrant composite storage listener notification; scheduling a list update.");
+            if (!this.dispatchingListUpdate) {
+                this.listUpdatePending = true;
+            }
+            return;
+        }
+
+        this.dispatchingListeners = true;
+        this.dispatchingListUpdate = listUpdate;
+        this.listenerDispatchBuffer.clear();
+        this.listenerDispatchBuffer.addAll(this.listeners);
+        try {
+            for (int i = 0; i < this.listenerDispatchBuffer.size(); i++) {
+                var registration = this.listenerDispatchBuffer.get(i);
+                if (!registration.active) {
+                    continue;
+                }
+                if (!registration.listener.isValid(registration.verificationToken)) {
+                    registration.active = false;
+                    continue;
+                }
+                if (listUpdate) {
+                    registration.listener.onListUpdate();
+                } else {
+                    registration.listener.onStackChange(what, delta);
+                }
+            }
+        } finally {
+            this.listenerDispatchBuffer.clear();
+            this.dispatchingListUpdate = false;
+            this.dispatchingListeners = false;
+        }
+        removeInactiveListeners();
+        flushPendingListUpdate();
+    }
+
+    private void removeInactiveListeners() {
+        for (int i = this.listeners.size() - 1; i >= 0; i--) {
+            if (!this.listeners.get(i).active) {
+                this.listeners.remove(i);
+            }
+        }
+        if (this.listeners.isEmpty() && this.sourcesBound) {
+            unbindSources();
+            invalidateLocalCaches();
+        }
+    }
+
+    private void flushPendingListUpdate() {
+        if (this.listUpdatePending && !this.processingSourceCallback && !this.dispatchingListeners) {
+            this.listUpdatePending = false;
+            notifyListUpdate();
+        }
+    }
+
+    private final class SourceGroup implements MEStorageChangeListener {
+        private final ExternalStorageMonitor monitor;
+        private final StorageFilter storageFilter;
+        private final Thread ownerThread;
+        private final ObjectList<ExternalStorageFacade> facades = new ObjectArrayList<>();
+
+        private SourceGroup(ExternalStorageMonitor monitor, StorageFilter storageFilter, Thread ownerThread) {
+            this.monitor = monitor;
+            this.storageFilter = storageFilter;
+            this.ownerThread = ownerThread;
+        }
+
+        private void addFacade(ExternalStorageFacade facade) {
+            if (facade.getStorageFilter() != this.storageFilter) {
+                throw new IllegalStateException("One external storage monitor cannot expose different filtered views.");
+            }
+            this.facades.add(facade);
+        }
+
+        private boolean accepts(AEKey what) {
+            for (int i = 0; i < this.facades.size(); i++) {
+                if (this.facades.get(i).acceptsMonitorKey(what)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public boolean isValid(Object verificationToken) {
+            return verificationToken == this && sourcesBound && sourceGroups.get(this.monitor) == this;
+        }
+
+        @Override
+        public void onStackChange(AEKey what, long delta) {
+            if (Thread.currentThread() != this.ownerThread) {
+                AELog.error("External storage %s invoked a callback from the wrong thread.", this.monitor);
+                eventDirty = true;
+                requestListUpdate();
+                return;
+            }
+            if (processingSourceCallback || dispatchingListeners) {
+                AELog.error("Reentrant external storage callback from %s; scheduling a list update.", this.monitor);
+                eventDirty = true;
+                requestListUpdate();
+                return;
+            }
+            if (!accepts(what)) {
+                AELog.error("External storage %s reported an incompatible resource %s.", this.monitor, what);
+                eventDirty = true;
+                requestListUpdate();
+                return;
+            }
+            processingSourceCallback = true;
+            try {
+                applyEventDelta(what, delta, this.monitor);
+            } finally {
+                processingSourceCallback = false;
+                flushPendingListUpdate();
+            }
+        }
+
+        @Override
+        public void onListUpdate() {
+            if (Thread.currentThread() != this.ownerThread) {
+                AELog.error("External storage %s invalidated its list from the wrong thread.", this.monitor);
+            }
+            eventDirty = true;
+            requestListUpdate();
+        }
+    }
+
+    private static final class ListenerRegistration {
+        private final MEStorageChangeListener listener;
+        private final Object verificationToken;
+        private boolean active = true;
+
+        private ListenerRegistration(MEStorageChangeListener listener, Object verificationToken) {
+            this.listener = listener;
+            this.verificationToken = verificationToken;
         }
     }
 }

--- a/src/main/java/ae2/me/storage/ExternalStorageFacade.java
+++ b/src/main/java/ae2/me/storage/ExternalStorageFacade.java
@@ -1,6 +1,8 @@
 package ae2.me.storage;
 
+import ae2.api.behaviors.ExternalStorageMonitor;
 import ae2.api.config.Actionable;
+import ae2.api.config.StorageFilter;
 import ae2.api.networking.security.IActionSource;
 import ae2.api.stacks.AEFluidKey;
 import ae2.api.stacks.AEItemKey;
@@ -27,9 +29,15 @@ import java.util.Set;
  * Adapts external platform storage to behave like an {@link MEStorage}.
  */
 public abstract class ExternalStorageFacade implements MEStorage {
+    @Nullable
+    private final ExternalStorageMonitor externalMonitor;
     protected boolean extractableOnly;
     @Nullable
     private Runnable changeListener;
+
+    private ExternalStorageFacade(@Nullable ExternalStorageMonitor externalMonitor) {
+        this.externalMonitor = externalMonitor;
+    }
 
     public static ExternalStorageFacade of(IFluidHandler handler) {
         return new FluidHandlerFacade(handler);
@@ -42,6 +50,17 @@ public abstract class ExternalStorageFacade implements MEStorage {
     public void setChangeListener(@Nullable Runnable listener) {
         this.changeListener = listener;
     }
+
+    @Nullable
+    ExternalStorageMonitor getExternalMonitor() {
+        return this.externalMonitor;
+    }
+
+    StorageFilter getStorageFilter() {
+        return this.extractableOnly ? StorageFilter.EXTRACTABLE_ONLY : StorageFilter.NONE;
+    }
+
+    abstract boolean acceptsMonitorKey(AEKey what);
 
     public abstract int getSlots();
 
@@ -91,7 +110,13 @@ public abstract class ExternalStorageFacade implements MEStorage {
         private final IItemHandler handler;
 
         public ItemHandlerFacade(IItemHandler handler) {
+            super(handler instanceof ExternalStorageMonitor monitor ? monitor : null);
             this.handler = handler;
+        }
+
+        @Override
+        boolean acceptsMonitorKey(AEKey what) {
+            return what != null;
         }
 
         /**
@@ -325,7 +350,13 @@ public abstract class ExternalStorageFacade implements MEStorage {
         private final IFluidHandler handler;
 
         public FluidHandlerFacade(IFluidHandler handler) {
+            super(handler instanceof ExternalStorageMonitor monitor ? monitor : null);
             this.handler = handler;
+        }
+
+        @Override
+        boolean acceptsMonitorKey(AEKey what) {
+            return what instanceof AEFluidKey;
         }
 
         @Override

--- a/src/main/java/ae2/me/storage/MEInventoryHandler.java
+++ b/src/main/java/ae2/me/storage/MEInventoryHandler.java
@@ -178,6 +178,13 @@ public class MEInventoryHandler extends DelegatingMEInventory {
         return allowExtraction && passesBlackOrWhitelist(request);
     }
 
+    /**
+     * Tests whether a key from an already enumerated delegate cache is visible through this handler's read filters.
+     */
+    protected boolean isVisibleInAvailableStacks(AEKey what) {
+        return !shouldFilterVisibleContents() || canExtract(what);
+    }
+
     private boolean shouldFilterReads() {
         return this.readPartitionFiltering || this.filterOnExtraction;
     }

--- a/src/main/java/ae2/me/storage/NetworkStorage.java
+++ b/src/main/java/ae2/me/storage/NetworkStorage.java
@@ -23,6 +23,9 @@ import ae2.api.networking.security.IActionSource;
 import ae2.api.stacks.AEKey;
 import ae2.api.stacks.KeyCounter;
 import ae2.api.storage.MEStorage;
+import ae2.api.storage.MEStorageChangeListener;
+import ae2.api.storage.MEStorageMonitor;
+import ae2.core.AELog;
 import ae2.core.localization.GuiText;
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
@@ -35,18 +38,31 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.IdentityHashMap;
-import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
-public class NetworkStorage implements MEStorage {
+public class NetworkStorage implements MEStorageMonitor {
     private static final IntComparator PRIORITY_SORTER = (first, second) -> Integer.compare(second, first);
-    private final Int2ObjectSortedMap<List<MEStorage>> priorityInventory = new Int2ObjectRBTreeMap<>(PRIORITY_SORTER);
+    private final Int2ObjectSortedMap<ObjectList<MEStorage>> priorityInventory =
+        new Int2ObjectRBTreeMap<>(PRIORITY_SORTER);
     private final ObjectList<MEStorage> secondPassInventories = new ObjectArrayList<>();
+    private final ObjectList<ListenerRegistration> listeners = new ObjectArrayList<>();
+    private final ObjectList<ListenerRegistration> listenerDispatchBuffer = new ObjectArrayList<>();
+    private final Supplier<KeyCounter> cachedContents;
+    private final Runnable legacyMutationCallback;
     private boolean mountsInUse;
     @Nullable
-    private List<QueuedOperation> queuedOperations;
+    private ObjectList<QueuedOperation> queuedOperations;
     @Nullable
     private Set<MEStorage> queuedRemovals;
+    private boolean dispatchingListeners;
+    private boolean dispatchingListUpdate;
+    private boolean listUpdatePending;
+
+    public NetworkStorage(Supplier<KeyCounter> cachedContents, Runnable legacyMutationCallback) {
+        this.cachedContents = cachedContents;
+        this.legacyMutationCallback = legacyMutationCallback;
+    }
 
     public void mount(int priority, MEStorage inventory) {
         if (this.mountsInUse) {
@@ -76,8 +92,15 @@ public class NetworkStorage implements MEStorage {
         var iterator = this.priorityInventory.int2ObjectEntrySet().iterator();
         while (iterator.hasNext()) {
             var entry = iterator.next();
-            List<MEStorage> inventories = entry.getValue();
-            if (inventories.remove(inventory) && inventories.isEmpty()) {
+            var inventories = entry.getValue();
+            boolean removed = false;
+            for (int i = inventories.size() - 1; i >= 0; i--) {
+                if (inventories.get(i) == inventory) {
+                    inventories.remove(i);
+                    removed = true;
+                }
+            }
+            if (removed && inventories.isEmpty()) {
                 iterator.remove();
             }
         }
@@ -97,8 +120,9 @@ public class NetworkStorage implements MEStorage {
 
         this.mountsInUse = true;
         try {
-            for (List<MEStorage> inventories : this.priorityInventory.values()) {
-                for (MEStorage inventory : inventories) {
+            for (var inventories : this.priorityInventory.values()) {
+                for (int i = 0; i < inventories.size(); i++) {
+                    var inventory = inventories.get(i);
                     if (remaining <= 0) {
                         break;
                     }
@@ -106,16 +130,19 @@ public class NetworkStorage implements MEStorage {
                         continue;
                     }
                     if (inventory.isStickyStorageFor(what, source)) {
-                        remaining -= inventory.insert(what, remaining, mode, source);
+                        long inserted = inventory.insert(what, remaining, mode, source);
+                        remaining -= inserted;
+                        legacyStorageChanged(inventory, inserted, mode);
                         stickyStorageFound = true;
                     }
                 }
             }
 
             if (!stickyStorageFound) {
-                for (List<MEStorage> inventories : this.priorityInventory.values()) {
+                for (var inventories : this.priorityInventory.values()) {
                     this.secondPassInventories.clear();
-                    for (MEStorage inventory : inventories) {
+                    for (int i = 0; i < inventories.size(); i++) {
+                        var inventory = inventories.get(i);
                         if (remaining <= 0) {
                             break;
                         }
@@ -123,20 +150,25 @@ public class NetworkStorage implements MEStorage {
                             continue;
                         }
                         if (inventory.isPreferredStorageFor(what, source)) {
-                            remaining -= inventory.insert(what, remaining, mode, source);
+                            long inserted = inventory.insert(what, remaining, mode, source);
+                            remaining -= inserted;
+                            legacyStorageChanged(inventory, inserted, mode);
                         } else {
                             this.secondPassInventories.add(inventory);
                         }
                     }
 
-                    for (MEStorage inventory : this.secondPassInventories) {
+                    for (int i = 0; i < this.secondPassInventories.size(); i++) {
+                        var inventory = this.secondPassInventories.get(i);
                         if (remaining <= 0) {
                             break;
                         }
                         if (isQueuedForRemoval(inventory)) {
                             continue;
                         }
-                        remaining -= inventory.insert(what, remaining, mode, source);
+                        long inserted = inventory.insert(what, remaining, mode, source);
+                        remaining -= inserted;
+                        legacyStorageChanged(inventory, inserted, mode);
                     }
                 }
             }
@@ -161,15 +193,18 @@ public class NetworkStorage implements MEStorage {
 
         this.mountsInUse = true;
         try {
-            for (List<MEStorage> inventories : this.priorityInventory.values()) {
-                for (MEStorage inventory : inventories) {
+            for (var inventories : this.priorityInventory.values()) {
+                for (int i = 0; i < inventories.size(); i++) {
+                    var inventory = inventories.get(i);
                     if (extracted >= amount) {
                         break;
                     }
                     if (isQueuedForRemoval(inventory)) {
                         continue;
                     }
-                    extracted += inventory.extract(what, amount - extracted, mode, source);
+                    long extractedNow = inventory.extract(what, amount - extracted, mode, source);
+                    extracted += extractedNow;
+                    legacyStorageChanged(inventory, extractedNow, mode);
                 }
             }
         } finally {
@@ -182,10 +217,18 @@ public class NetworkStorage implements MEStorage {
 
     @Override
     public void getAvailableStacks(KeyCounter out) {
+        out.addAll(this.cachedContents.get());
+    }
+
+    /**
+     * Enumerates mounted storage directly. Only the owning storage service uses this to rebuild its aggregate cache.
+     */
+    public void getAvailableStacksRaw(KeyCounter out) {
         this.mountsInUse = true;
         try {
-            for (List<MEStorage> inventories : this.priorityInventory.values()) {
-                for (MEStorage inventory : inventories) {
+            for (var inventories : this.priorityInventory.values()) {
+                for (int i = 0; i < inventories.size(); i++) {
+                    var inventory = inventories.get(i);
                     if (isQueuedForRemoval(inventory)) {
                         continue;
                     }
@@ -206,6 +249,95 @@ public class NetworkStorage implements MEStorage {
     }
 
     @Override
+    public void addListener(MEStorageChangeListener listener, Object verificationToken) {
+        for (int i = 0; i < this.listeners.size(); i++) {
+            var registration = this.listeners.get(i);
+            if (registration.listener == listener) {
+                throw new IllegalStateException("The storage listener is already registered.");
+            }
+        }
+        this.listeners.add(new ListenerRegistration(listener, verificationToken));
+    }
+
+    @Override
+    public void removeListener(MEStorageChangeListener listener) {
+        for (int i = this.listeners.size() - 1; i >= 0; i--) {
+            var registration = this.listeners.get(i);
+            if (registration.listener == listener) {
+                registration.active = false;
+                this.listeners.remove(i);
+            }
+        }
+    }
+
+    public boolean hasListeners() {
+        return !this.listeners.isEmpty();
+    }
+
+    public boolean isDispatchingListeners() {
+        return this.dispatchingListeners;
+    }
+
+    public void postChange(AEKey what, long delta) {
+        dispatchListeners(what, delta, false);
+    }
+
+    public void postListUpdate() {
+        dispatchListeners(null, 0, true);
+    }
+
+    private void dispatchListeners(@Nullable AEKey what, long delta, boolean listUpdate) {
+        if (this.dispatchingListeners) {
+            AELog.error("Reentrant network storage listener notification; scheduling a full storage refresh.");
+            if (!this.listUpdatePending && !this.dispatchingListUpdate) {
+                this.listUpdatePending = true;
+                this.legacyMutationCallback.run();
+            }
+            return;
+        }
+
+        this.dispatchingListeners = true;
+        this.dispatchingListUpdate = listUpdate;
+        this.listenerDispatchBuffer.clear();
+        this.listenerDispatchBuffer.addAll(this.listeners);
+        try {
+            for (int i = 0; i < this.listenerDispatchBuffer.size(); i++) {
+                var registration = this.listenerDispatchBuffer.get(i);
+                if (!registration.active) {
+                    continue;
+                }
+                if (!registration.listener.isValid(registration.verificationToken)) {
+                    registration.active = false;
+                    continue;
+                }
+                if (listUpdate) {
+                    registration.listener.onListUpdate();
+                } else {
+                    registration.listener.onStackChange(what, delta);
+                }
+            }
+        } finally {
+            this.listenerDispatchBuffer.clear();
+            this.dispatchingListUpdate = false;
+            this.dispatchingListeners = false;
+        }
+        removeInactiveListeners();
+
+        if (this.listUpdatePending) {
+            this.listUpdatePending = false;
+            postListUpdate();
+        }
+    }
+
+    private void removeInactiveListeners() {
+        for (int i = this.listeners.size() - 1; i >= 0; i--) {
+            if (!this.listeners.get(i).active) {
+                this.listeners.remove(i);
+            }
+        }
+    }
+
+    @Override
     public ITextComponent getDescription() {
         return GuiText.MENetworkStorage.text();
     }
@@ -216,10 +348,11 @@ public class NetworkStorage implements MEStorage {
             return;
         }
 
-        List<QueuedOperation> queued = this.queuedOperations;
+        ObjectList<QueuedOperation> queued = this.queuedOperations;
         this.queuedOperations = null;
         this.queuedRemovals = null;
-        for (QueuedOperation operation : queued) {
+        for (int i = 0; i < queued.size(); i++) {
+            var operation = queued.get(i);
             if (operation.mount()) {
                 mount(operation.priority(), operation.inventory());
             } else {
@@ -232,6 +365,23 @@ public class NetworkStorage implements MEStorage {
         return this.queuedRemovals != null && this.queuedRemovals.contains(inventory);
     }
 
+    private void legacyStorageChanged(MEStorage inventory, long amount, Actionable mode) {
+        if (amount > 0 && mode == Actionable.MODULATE && !(inventory instanceof MEStorageMonitor)) {
+            this.legacyMutationCallback.run();
+        }
+    }
+
     private record QueuedOperation(boolean mount, int priority, MEStorage inventory) {
+    }
+
+    private static final class ListenerRegistration {
+        private final MEStorageChangeListener listener;
+        private final Object verificationToken;
+        private boolean active = true;
+
+        private ListenerRegistration(MEStorageChangeListener listener, Object verificationToken) {
+            this.listener = listener;
+            this.verificationToken = verificationToken;
+        }
     }
 }

--- a/src/main/java/ae2/parts/automation/special/PreciseStorageBusPart.java
+++ b/src/main/java/ae2/parts/automation/special/PreciseStorageBusPart.java
@@ -100,7 +100,7 @@ public class PreciseStorageBusPart extends StorageBusPart {
             if (targetAmount <= 0) {
                 return 0;
             }
-            long missing = targetAmount - this.getDelegate().getAvailableStacks().get(what);
+            long missing = targetAmount - this.getCachedAmount(what);
             if (missing <= 0) {
                 return 0;
             }

--- a/src/main/java/ae2/parts/storagebus/StorageBusPart.java
+++ b/src/main/java/ae2/parts/storagebus/StorageBusPart.java
@@ -2,6 +2,7 @@ package ae2.parts.storagebus;
 
 import ae2.api.AECapabilities;
 import ae2.api.behaviors.ExternalStorageStrategy;
+import ae2.api.config.Actionable;
 import ae2.api.config.AccessRestriction;
 import ae2.api.config.FuzzyMode;
 import ae2.api.config.IncludeExclude;
@@ -21,16 +22,20 @@ import ae2.api.parts.IPartHost;
 import ae2.api.parts.IPartItem;
 import ae2.api.parts.IPartModel;
 import ae2.api.stacks.AEKeyType;
+import ae2.api.stacks.AEKey;
 import ae2.api.stacks.KeyCounter;
 import ae2.api.storage.IStorageMounts;
 import ae2.api.storage.IStorageProvider;
 import ae2.api.storage.MEStorage;
+import ae2.api.storage.MEStorageChangeListener;
+import ae2.api.storage.MEStorageMonitor;
 import ae2.api.util.AECableType;
 import ae2.api.util.IConfigManager;
 import ae2.api.util.IConfigManagerBuilder;
 import ae2.container.GuiIds;
 import ae2.container.ISubGui;
 import ae2.core.AppEng;
+import ae2.core.AELog;
 import ae2.core.definitions.AEItems;
 import ae2.core.gui.GuiOpener;
 import ae2.core.settings.TickRates;
@@ -55,6 +60,8 @@ import ae2.util.prioritylist.IPartitionList;
 import ae2.util.prioritylist.PrecisePriorityList;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectList;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -112,6 +119,7 @@ public class StorageBusPart extends UpgradeablePart
                                                           .build();
     private int priority;
     private PendingUpdateStatus updateStatus = PendingUpdateStatus.FAST_UPDATE;
+    private boolean externalStorageExtractableOnly;
     @Nullable
     private ITickingMonitor monitor;
     public StorageBusPart(IPartItem<?> partItem) {
@@ -120,6 +128,12 @@ public class StorageBusPart extends UpgradeablePart
             this::onCapabilityInvalidation);
         this.source = new MachineSource(this);
         getMainNode().addService(IStorageProvider.class, this).addService(IGridTickable.class, this);
+    }
+
+    @Override
+    public void removeFromWorld() {
+        this.handler.removeAllListeners();
+        super.removeFromWorld();
     }
 
     private static synchronized StatBase getRecursiveNetworkingStat() {
@@ -335,12 +349,18 @@ public class StorageBusPart extends UpgradeablePart
             this.updateStatus = PendingUpdateStatus.SLOW_UPDATE;
         }
 
-        if (!forceFullUpdate && this.handler.getDelegate() instanceof CompositeStorage compositeStorage
-            && !foundExternalApi.isEmpty()) {
-            compositeStorage.setStorages(foundExternalApi);
+        boolean extractableOnly = isExtractableOnly();
+        if (this.handler.getDelegate() instanceof CompositeStorage compositeStorage
+            && !foundExternalApi.isEmpty()
+            && (!forceFullUpdate || this.externalStorageExtractableOnly == extractableOnly)) {
+            if (!forceFullUpdate) {
+                compositeStorage.setStorages(foundExternalApi);
+            }
             this.handlerDescription = compositeStorage.getDescription();
+            configureHandler();
             return;
-        } else if (!forceFullUpdate && foundMonitor == this.handler.getDelegate()) {
+        } else if (foundMonitor == this.handler.getDelegate()) {
+            configureHandler();
             return;
         }
 
@@ -354,27 +374,19 @@ public class StorageBusPart extends UpgradeablePart
             this.handlerDescription = newInventory.getDescription();
         } else if (!foundExternalApi.isEmpty()) {
             newInventory = new CompositeStorage(foundExternalApi);
+            this.externalStorageExtractableOnly = extractableOnly;
             this.handlerDescription = newInventory.getDescription();
         } else {
             newInventory = NullInventory.of();
             this.handlerDescription = null;
         }
         this.handler.setDelegate(newInventory);
-
-        this.handler.setAccessRestriction(this.getConfigManager().getSetting(Settings.ACCESS));
-        this.handler.setWhitelist(isUpgradedWith(AEItems.INVERTER_CARD) ? IncludeExclude.BLACKLIST
-            : IncludeExclude.WHITELIST);
-        var partitionList = createFilter();
-        this.handler.setPartitionList(partitionList);
-        this.handler.setReadPartitionFiltering(!partitionList.isEmpty());
-        this.handler.setVoidOverflow(this.isUpgradedWith(AEItems.VOID_CARD));
-        this.handler.setSticky(this.isUpgradedWith(AEItems.STICKY_CARD));
-
-        boolean filterOnExtract = this.getConfigManager().getSetting(Settings.FILTER_ON_EXTRACT) == YesNo.YES;
-        this.handler.setExtractFiltering(filterOnExtract, isExtractableOnly() && filterOnExtract);
+        configureHandler();
 
         if (newInventory instanceof ITickingMonitor) {
             this.monitor = (ITickingMonitor) newInventory;
+        } else if (!(newInventory instanceof NullInventory) && !(newInventory instanceof MEStorageMonitor)) {
+            this.monitor = this.handler;
         } else {
             this.monitor = null;
         }
@@ -392,6 +404,21 @@ public class StorageBusPart extends UpgradeablePart
         if (wasRegistered != this.hasRegisteredCellToNetwork()) {
             remountStorage();
         }
+    }
+
+    private void configureHandler() {
+        this.handler.setAccessRestriction(this.getConfigManager().getSetting(Settings.ACCESS));
+        this.handler.setWhitelist(isUpgradedWith(AEItems.INVERTER_CARD) ? IncludeExclude.BLACKLIST
+            : IncludeExclude.WHITELIST);
+        var partitionList = createFilter();
+        this.handler.setPartitionList(partitionList);
+        this.handler.setReadPartitionFiltering(!partitionList.isEmpty());
+        this.handler.setVoidOverflow(this.isUpgradedWith(AEItems.VOID_CARD));
+        this.handler.setSticky(this.isUpgradedWith(AEItems.STICKY_CARD));
+
+        boolean filterOnExtract = this.getConfigManager().getSetting(Settings.FILTER_ON_EXTRACT) == YesNo.YES;
+        this.handler.setExtractFiltering(filterOnExtract, isExtractableOnly() && filterOnExtract);
+        this.handler.configurationChanged();
     }
 
     protected boolean isExtractableOnly() {
@@ -527,7 +554,23 @@ public class StorageBusPart extends UpgradeablePart
         NO_UPDATE
     }
 
-    protected static class StorageBusInventory extends MEInventoryHandler {
+    protected static class StorageBusInventory extends MEInventoryHandler implements MEStorageMonitor, ITickingMonitor {
+        private final ObjectList<ListenerRegistration> listeners = new ObjectArrayList<>();
+        private final ObjectList<ListenerRegistration> listenerDispatchBuffer = new ObjectArrayList<>();
+        private final DelegateListener delegateListener = new DelegateListener();
+        private KeyCounter targetCache = KeyCounter.saturating();
+        private KeyCounter targetScratch = KeyCounter.saturating();
+        @Nullable
+        private MEStorageMonitor monitoredDelegate;
+        @Nullable
+        private Thread delegateThread;
+        private boolean cacheDirty = true;
+        private boolean cacheInitialized;
+        private boolean processingDelegateCallback;
+        private boolean dispatchingListeners;
+        private boolean dispatchingListUpdate;
+        private boolean listUpdatePending;
+
         protected StorageBusInventory(MEStorage inventory) {
             super(inventory);
         }
@@ -539,16 +582,365 @@ public class StorageBusPart extends UpgradeablePart
 
         @Override
         protected void setDelegate(MEStorage delegate) {
+            unbindDelegateMonitor();
             super.setDelegate(delegate);
+            this.cacheInitialized = false;
+            this.cacheDirty = true;
+            if (!this.listeners.isEmpty()) {
+                bindDelegateMonitor();
+                refreshTarget(false);
+            }
+            notifyListUpdate();
         }
 
         public void setAccessRestriction(AccessRestriction setting) {
             setAllowExtraction(setting.isAllowExtraction());
             setAllowInsertion(setting.isAllowInsertion());
         }
+
+        public void configurationChanged() {
+            notifyListUpdate();
+        }
+
+        protected long getCachedAmount(AEKey what) {
+            ensureCache();
+            return Math.max(0, this.targetCache.get(what));
+        }
+
+        @Override
+        public long insert(AEKey what, long amount, Actionable mode, IActionSource source) {
+            long inserted = super.insert(what, amount, mode, source);
+            if (inserted > 0 && mode == Actionable.MODULATE && this.monitoredDelegate == null) {
+                markCacheDirty();
+            }
+            return inserted;
+        }
+
+        @Override
+        public long extract(AEKey what, long amount, Actionable mode, IActionSource source) {
+            long extracted = super.extract(what, amount, mode, source);
+            if (extracted > 0 && mode == Actionable.MODULATE && this.monitoredDelegate == null) {
+                markCacheDirty();
+            }
+            return extracted;
+        }
+
+        @Override
+        public void getAvailableStacks(KeyCounter out) {
+            ensureCache();
+            for (var entry : this.targetCache) {
+                if (entry.getLongValue() > 0 && isVisibleInAvailableStacks(entry.getKey())) {
+                    out.add(entry.getKey(), entry.getLongValue());
+                }
+            }
+        }
+
+        @Override
+        public TickRateModulation onTick() {
+            if (this.monitoredDelegate != null) {
+                return TickRateModulation.SLEEP;
+            }
+
+            boolean publishChanges = this.cacheInitialized && !this.cacheDirty && !this.listeners.isEmpty();
+            boolean changed = refreshTarget(publishChanges);
+            return changed ? TickRateModulation.URGENT : TickRateModulation.SLOWER;
+        }
+
+        @Override
+        public void addListener(MEStorageChangeListener listener, Object verificationToken) {
+            for (int i = 0; i < this.listeners.size(); i++) {
+                var registration = this.listeners.get(i);
+                if (registration.listener == listener) {
+                    throw new IllegalStateException("The storage listener is already registered.");
+                }
+            }
+
+            boolean firstListener = this.listeners.isEmpty();
+            this.listeners.add(new ListenerRegistration(listener, verificationToken));
+            if (firstListener) {
+                bindDelegateMonitor();
+                refreshTarget(false);
+            }
+        }
+
+        @Override
+        public void removeListener(MEStorageChangeListener listener) {
+            for (int i = this.listeners.size() - 1; i >= 0; i--) {
+                var registration = this.listeners.get(i);
+                if (registration.listener == listener) {
+                    registration.active = false;
+                    this.listeners.remove(i);
+                }
+            }
+            if (this.listeners.isEmpty()) {
+                unbindDelegateMonitor();
+            }
+        }
+
+        private void removeAllListeners() {
+            for (int i = 0; i < this.listeners.size(); i++) {
+                this.listeners.get(i).active = false;
+            }
+            this.listeners.clear();
+            unbindDelegateMonitor();
+        }
+
+        private void bindDelegateMonitor() {
+            if (this.monitoredDelegate != null) {
+                throw new IllegalStateException("The storage bus delegate monitor is already bound.");
+            }
+            if (getDelegate() instanceof MEStorageMonitor monitor) {
+                this.monitoredDelegate = monitor;
+                this.delegateThread = Thread.currentThread();
+                monitor.addListener(this.delegateListener, getDelegate());
+            }
+        }
+
+        private void unbindDelegateMonitor() {
+            if (this.monitoredDelegate != null) {
+                this.monitoredDelegate.removeListener(this.delegateListener);
+                this.monitoredDelegate = null;
+                this.delegateThread = null;
+            }
+        }
+
+        private void ensureCache() {
+            if (!this.cacheInitialized || this.cacheDirty) {
+                refreshTarget(false);
+            }
+        }
+
+        private boolean refreshTarget(boolean publishChanges) {
+            this.targetScratch.reset();
+            getDelegate().getAvailableStacks(this.targetScratch);
+            this.targetScratch.removeZeros();
+            boolean changed = hasDifference(this.targetCache, this.targetScratch);
+            if (publishChanges) {
+                publishReplacement(this.targetCache, this.targetScratch);
+            }
+            var previous = this.targetCache;
+            this.targetCache = this.targetScratch;
+            this.targetScratch = previous;
+            this.cacheInitialized = true;
+            this.cacheDirty = false;
+            return changed;
+        }
+
+        private boolean hasDifference(KeyCounter previous, KeyCounter replacement) {
+            for (var entry : replacement) {
+                if (entry.getLongValue() != previous.get(entry.getKey())) {
+                    return true;
+                }
+            }
+            for (var entry : previous) {
+                if (entry.getLongValue() > 0 && replacement.get(entry.getKey()) == 0) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void publishReplacement(KeyCounter previous, KeyCounter replacement) {
+            for (var entry : replacement) {
+                long oldAmount = Math.max(0, previous.get(entry.getKey()));
+                long delta = entry.getLongValue() - oldAmount;
+                if (delta != 0) {
+                    if (isVisibleInAvailableStacks(entry.getKey())) {
+                        notifyDelta(entry.getKey(), delta);
+                    }
+                }
+            }
+            for (var entry : previous) {
+                if (entry.getLongValue() > 0 && replacement.get(entry.getKey()) == 0) {
+                    if (isVisibleInAvailableStacks(entry.getKey())) {
+                        notifyDelta(entry.getKey(), -entry.getLongValue());
+                    }
+                }
+            }
+        }
+
+        private void applyDelegateDelta(AEKey what, long delta) {
+            if (what == null || delta == 0) {
+                if (what == null) {
+                    AELog.error("Storage bus target reported a null storage key.");
+                    markCacheDirty();
+                }
+                return;
+            }
+            if (this.cacheDirty) {
+                requestListUpdate();
+                return;
+            }
+
+            long current = Math.max(0, this.targetCache.get(what));
+            if ((current == Long.MAX_VALUE && delta < 0)
+                || (delta < 0 && (delta == Long.MIN_VALUE || current < -delta))) {
+                AELog.error("Storage bus target reported delta %d for %s with cached amount %d.", delta, what, current);
+                markCacheDirty();
+                return;
+            }
+            long updated = delta > 0 && current > Long.MAX_VALUE - delta ? Long.MAX_VALUE : current + delta;
+            if (updated == 0) {
+                this.targetCache.remove(what);
+            } else {
+                this.targetCache.set(what, updated);
+            }
+            if (isVisibleInAvailableStacks(what)) {
+                notifyDelta(what, delta);
+            }
+        }
+
+        private void markCacheDirty() {
+            if (!this.cacheDirty) {
+                this.cacheDirty = true;
+                notifyListUpdate();
+            }
+        }
+
+        private void notifyDelta(AEKey what, long delta) {
+            dispatchListeners(what, delta, false);
+        }
+
+        private void notifyListUpdate() {
+            if (this.listeners.isEmpty()) {
+                return;
+            }
+            dispatchListeners(null, 0, true);
+        }
+
+        private void requestListUpdate() {
+            if (this.listeners.isEmpty()) {
+                return;
+            }
+            if (this.dispatchingListeners || this.processingDelegateCallback) {
+                if (!this.dispatchingListUpdate) {
+                    this.listUpdatePending = true;
+                }
+            } else {
+                notifyListUpdate();
+            }
+        }
+
+        private void dispatchListeners(@Nullable AEKey what, long delta, boolean listUpdate) {
+            if (this.dispatchingListeners) {
+                AELog.error("Reentrant storage bus listener notification; scheduling a target rescan.");
+                this.cacheDirty = true;
+                if (!this.dispatchingListUpdate) {
+                    this.listUpdatePending = true;
+                }
+                return;
+            }
+
+            this.dispatchingListeners = true;
+            this.dispatchingListUpdate = listUpdate;
+            this.listenerDispatchBuffer.clear();
+            this.listenerDispatchBuffer.addAll(this.listeners);
+            try {
+                for (int i = 0; i < this.listenerDispatchBuffer.size(); i++) {
+                    var registration = this.listenerDispatchBuffer.get(i);
+                    if (!registration.active) {
+                        continue;
+                    }
+                    if (!registration.listener.isValid(registration.verificationToken)) {
+                        registration.active = false;
+                        continue;
+                    }
+                    if (listUpdate) {
+                        registration.listener.onListUpdate();
+                    } else {
+                        registration.listener.onStackChange(what, delta);
+                    }
+                }
+            } finally {
+                this.listenerDispatchBuffer.clear();
+                this.dispatchingListUpdate = false;
+                this.dispatchingListeners = false;
+            }
+            removeInactiveListeners();
+
+            flushPendingListUpdate();
+        }
+
+        private void flushPendingListUpdate() {
+            if (this.listUpdatePending && !this.processingDelegateCallback && !this.dispatchingListeners) {
+                this.listUpdatePending = false;
+                notifyListUpdate();
+            }
+        }
+
+        private void removeInactiveListeners() {
+            for (int i = this.listeners.size() - 1; i >= 0; i--) {
+                if (!this.listeners.get(i).active) {
+                    this.listeners.remove(i);
+                }
+            }
+            if (this.listeners.isEmpty()) {
+                unbindDelegateMonitor();
+            }
+        }
+
+        private final class DelegateListener implements MEStorageChangeListener {
+            @Override
+            public boolean isValid(Object verificationToken) {
+                return verificationToken == getDelegate()
+                    && monitoredDelegate == getDelegate()
+                    && !listeners.isEmpty();
+            }
+
+            @Override
+            public void onStackChange(AEKey what, long delta) {
+                if (Thread.currentThread() != delegateThread) {
+                    AELog.error("Storage bus target invoked a callback from the wrong thread.");
+                    cacheDirty = true;
+                    return;
+                }
+                if (processingDelegateCallback || dispatchingListeners) {
+                    AELog.error("Reentrant storage bus target callback; scheduling a target rescan.");
+                    cacheDirty = true;
+                    requestListUpdate();
+                    return;
+                }
+                processingDelegateCallback = true;
+                try {
+                    applyDelegateDelta(what, delta);
+                } finally {
+                    processingDelegateCallback = false;
+                    flushPendingListUpdate();
+                }
+            }
+
+            @Override
+            public void onListUpdate() {
+                if (Thread.currentThread() != delegateThread) {
+                    AELog.error("Storage bus target invalidated its list from the wrong thread.");
+                    cacheDirty = true;
+                    return;
+                }
+                if (processingDelegateCallback || dispatchingListeners) {
+                    AELog.error("Reentrant storage bus target list update; scheduling a target rescan.");
+                    cacheDirty = true;
+                    requestListUpdate();
+                    return;
+                }
+                processingDelegateCallback = true;
+                try {
+                    markCacheDirty();
+                } finally {
+                    processingDelegateCallback = false;
+                    flushPendingListUpdate();
+                }
+            }
+        }
+
+        private static final class ListenerRegistration {
+            private final MEStorageChangeListener listener;
+            private final Object verificationToken;
+            private boolean active = true;
+
+            private ListenerRegistration(MEStorageChangeListener listener, Object verificationToken) {
+                this.listener = listener;
+                this.verificationToken = verificationToken;
+            }
+        }
     }
-
-
-
-
 }


### PR DESCRIPTION
- add signed-delta storage monitor APIs for ME and external storage
- lazily initialize network, storage bus, and composite storage caches
- propagate subnet changes without repeated full inventory scans
- retain polling fallback for legacy storage handlers
- bind monitor listeners only while actively observed and cleanly unbind them
- reuse KeyCounter buffers and remove stale zero entries
- use indexed traversal for random-access storage and listener lists
- use cached target amounts for precise storage buses
- document incremental storage monitoring behavior and extension contracts