### PR TITLE
Fix Forge item tooltip lifecycle in AEBaseGui

### DIFF
--- a/src/main/java/ae2/client/gui/AEBaseGui.java
+++ b/src/main/java/ae2/client/gui/AEBaseGui.java
@@ -90,6 +90,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
+import net.minecraftforge.fml.client.config.GuiUtils;
 import net.minecraftforge.fml.common.Optional;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.input.Keyboard;
@@ -512,7 +513,12 @@ public abstract class AEBaseGui<T extends AEBaseContainer> extends GuiContainer 
             return false;
         }
 
-        drawHoveringTextAtTopZ(getItemToolTip(displayStack), mouseX, mouseY);
+        GuiUtils.preItemToolTip(displayStack);
+        try {
+            drawHoveringTextAtTopZ(getItemToolTip(displayStack), mouseX, mouseY);
+        } finally {
+            GuiUtils.postItemToolTip();
+        }
         return true;
     }
 


### PR DESCRIPTION
该pr修复了神秘的物品 tooltip 中源质在 PostBackground 阶段渲染，导致如图所示的仅留空行但是无渲染的问题。
<img width="470" height="182" alt="图片" src="https://github.com/user-attachments/assets/0ce042b9-75af-40b2-b19c-b18590f0f037" />